### PR TITLE
Some updates for X11 part

### DIFF
--- a/x11/gtk2/gtk_menu.c
+++ b/x11/gtk2/gtk_menu.c
@@ -839,6 +839,8 @@ cb_diskopen(GtkAction *action, gpointer user_data)
 		gtk_file_filter_add_pattern(filter, "*.[fF][lL][pP]");
 		gtk_file_filter_add_pattern(filter, "*.[bB][iI][nN]");
 		gtk_file_filter_add_pattern(filter, "*.[fF][iI][mM]");
+		gtk_file_filter_add_pattern(filter, "*.[iI][mM][gG]");
+		gtk_file_filter_add_pattern(filter, "*.[iI][mM][aA]");
 		gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filter);
 	}
 	filter = gtk_file_filter_new();
@@ -870,6 +872,8 @@ cb_diskopen(GtkAction *action, gpointer user_data)
 		gtk_file_filter_add_pattern(filter, "*.[fF][lL][pP]");
 		gtk_file_filter_add_pattern(filter, "*.[bB][iI][nN]");
 		gtk_file_filter_add_pattern(filter, "*.[fF][iI][mM]");
+		gtk_file_filter_add_pattern(filter, "*.[iI][mM][gG]");
+		gtk_file_filter_add_pattern(filter, "*.[iI][mM][aA]");
 		gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filter);
 	}
 	gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(dialog), filter);

--- a/x11/gtk2/gtk_mouse.c
+++ b/x11/gtk2/gtk_mouse.c
@@ -151,15 +151,33 @@ mouse_running(UINT8 flg)
 void
 mousemng_callback(void)
 {
-	int wx, wy;
-	int cx, cy;
+	static int active = 0;
+	static int wx, wy, wx0 = -1, wy0 = -1;
+	int cx, cy, l, t, r, b;
 
 	if (ms.lastmouse & 1) {
-		gdk_window_get_pointer(main_window->window, &wx, &wy, NULL);
 		getmaincenter(main_window, &cx, &cy);
-		ms.mousex += (short)((wx - cx) / 2);
-		ms.mousey += (short)((wy - cy) / 2);
-		gdk_window_set_pointer(main_window->window, cx, cy);
+		if (wx0 < 0 || wy0 < 0) {
+			wx = wx0 = cx; wy = wy0 = cy;
+		}
+		if (!active) {
+			active = 1;
+			wx0 = wx = cx; wy0 = wy = cy;
+			gdk_window_set_pointer(main_window->window, cx, cy);
+			return;
+		}
+
+		gdk_window_get_pointer(main_window->window, &wx, &wy, NULL);
+		ms.mousex += (short)((wx - wx0)/2);
+		ms.mousey += (short)((wy - wy0)/2);
+		wx0 = wx; wy0 = wy;
+		l = cx / 2; r = cx / 2 + cx; t = cy / 2; b = cy / 2 + cy;
+		if (wx <= l || wy <= t || wx >= r || wy >= b) {
+			wx = wx0 = cx; wy = wy0 = cy;
+			gdk_window_set_pointer(main_window->window, cx, cy);
+		}
+	} else {
+		active = 0;
 	}
 }
 


### PR DESCRIPTION
1. FDD selection added `*.img` and `*.ima` as supported floppy disk image file, which may have the same format as IBM-PC floppy disks and already supported by Neko Project II.
2. Updated `gtk_mouse.c` to make mouse moving more smoothly.