### PR TITLE
Respect the XDG base directory specification

### DIFF
--- a/sdl2/Makefile.gcw0
+++ b/sdl2/Makefile.gcw0
@@ -74,4 +74,3 @@ buildopk:
 
 uninstall:
 	rm /usr/local/bin/$(TARGET)
-	rm -rf -p $(HOME)/.config/np2kai

--- a/sdl2/Makefile.unix
+++ b/sdl2/Makefile.unix
@@ -63,11 +63,8 @@ clean:
 install:
 	strip $(TARGET)
 	cp $(TARGET) /usr/local/bin/
-	mkdir -p $(HOME)/.config/np2kai
-	chown $(SUDO_USER) $(HOME)/.config/np2kai
 
 
 uninstall:
 	rm /usr/local/bin/$(TARGET)
-	rm -rf -p $(HOME)/.config/np2kai
 

--- a/sdl2/Makefile.win
+++ b/sdl2/Makefile.win
@@ -64,11 +64,8 @@ clean:
 install:
 	strip $(TARGET)
 	cp $(TARGET) /usr/local/bin/
-	mkdir -p $(HOME)/.config/np2kai
-	chown $(SUDO_USER) $(HOME)/.config/np2kai
 
 
 uninstall:
 	rm /usr/local/bin/$(TARGET)
-	rm -rf -p $(HOME)/.config/np2kai
 

--- a/sdl2/Makefile21.unix
+++ b/sdl2/Makefile21.unix
@@ -78,11 +78,8 @@ clean:
 install:
 	strip $(TARGET)
 	cp $(TARGET) /usr/local/bin/
-	mkdir -p $(HOME)/.config/np2kai
-	chown $(SUDO_USER) $(HOME)/.config/np2kai
 
 
 uninstall:
 	rm /usr/local/bin/$(TARGET)
-	rm -rf -p $(HOME)/.config/np2kai
 

--- a/sdl2/Makefile21.win
+++ b/sdl2/Makefile21.win
@@ -79,11 +79,8 @@ clean:
 install:
 	strip $(TARGET)
 	cp $(TARGET) /usr/local/bin/
-	mkdir -p $(HOME)/.config/np2kai
-	chown $(SUDO_USER) $(HOME)/.config/np2kai
 
 
 uninstall:
 	rm /usr/local/bin/$(TARGET)
-	rm -rf -p $(HOME)/.config/np2kai
 

--- a/sdl2/np2.c
+++ b/sdl2/np2.c
@@ -192,8 +192,20 @@ int np2_main(int argc, char *argv[]) {
 	}
 
 #if !defined(__LIBRETRO__)
-	strcpy(np2cfg.biospath, getenv("HOME"));
-	strcat(np2cfg.biospath, "/.config/np2kai/");
+	char *config_home = getenv("XDG_CONFIG_HOME");
+	char *home = getenv("HOME");
+	if (config_home && config_home[0] == '/') {
+		/* base dir */
+		milstr_ncpy(np2cfg.biospath, config_home, sizeof(np2cfg.biospath));
+		milstr_ncat(np2cfg.biospath, "/np2kai/", sizeof(np2cfg.biospath));
+	} else if (home) {
+		/* base dir */
+		milstr_ncpy(np2cfg.biospath, home, sizeof(np2cfg.biospath));
+		milstr_ncat(np2cfg.biospath, "/.config/np2kai/", sizeof(np2cfg.biospath));
+	} else {
+		printf("$HOME isn't defined.\n");
+		goto np2main_err1;
+	}
 	file_setcd(np2cfg.biospath);
 #endif	/* __LIBRETRO__ */
 

--- a/x11/gtk2/gtk_main.c
+++ b/x11/gtk2/gtk_main.c
@@ -253,20 +253,29 @@ BRESULT
 gui_gtk_arginit(int *argcp, char ***argvp)
 {
 	char buf[MAX_PATH];
-	char *homeenv;
 
 	gtk_set_locale();
 	gtk_init(argcp, argvp);
 
-	homeenv = getenv("HOME");
-	if (homeenv) {
-		g_snprintf(buf, sizeof(buf), "%s/.config/xnp2kai/gtkrc", homeenv);
-		gtk_rc_add_default_file(buf);
-
-		g_snprintf(buf, sizeof(buf), "%s/.config/xnp2kai/accels", homeenv);
-		if (g_file_test(buf, G_FILE_TEST_IS_REGULAR))
-			gtk_accel_map_load(buf);
+	char *config_home = getenv("XDG_CONFIG_HOME");
+	char *home = getenv("HOME");
+	if (config_home && config_home[0] == '/') {
+		/* base dir */
+		g_snprintf(buf, sizeof(buf), "%s/xnp2kai/", config_home);
+	} else if (home) {
+		/* base dir */
+		g_snprintf(buf, sizeof(buf), "%s/.config/xnp2kai/", home);
+	} else {
+		g_printerr("$HOME isn't defined.\n");
+		exit(1);
 	}
+
+	g_strlcat(buf, "gtkrc", sizeof(buf));
+	gtk_rc_add_default_file(buf);
+
+	g_strlcat(buf, "accels", sizeof(buf));
+	if (g_file_test(buf, G_FILE_TEST_IS_REGULAR))
+		gtk_accel_map_load(buf);
 
 	return SUCCESS;
 }

--- a/x11/main.c
+++ b/x11/main.c
@@ -188,30 +188,38 @@ main(int argc, char *argv[])
 	argv += optind;
 
 	if (modulefile[0] == '\0') {
-		char *env = getenv("HOME");
-		if (env) {
+		char *config_home = getenv("XDG_CONFIG_HOME");
+		char *home = getenv("HOME");
+		if (config_home && config_home[0] == '/') {
 			/* base dir */
 			g_snprintf(modulefile, sizeof(modulefile),
-			    "%s/.config/xnp2kai/", env);
-			if (stat(modulefile, &sb) < 0) {
-				if (mkdir(modulefile, 0700) < 0) {
-					perror(modulefile);
-					exit(1);
-				}
-			} else if (!S_ISDIR(sb.st_mode)) {
-				g_printerr("%s isn't directory.\n",
-				    modulefile);
+			    "%s/xnp2kai/", config_home);
+		} else if (home) {
+			/* base dir */
+			g_snprintf(modulefile, sizeof(modulefile),
+			    "%s/.config/xnp2kai/", home);
+		} else {
+			g_printerr("$HOME isn't defined.\n");
+			exit(1);
+		}
+		if (stat(modulefile, &sb) < 0) {
+			if (mkdir(modulefile, 0700) < 0) {
+				perror(modulefile);
 				exit(1);
 			}
+		} else if (!S_ISDIR(sb.st_mode)) {
+			g_printerr("%s isn't directory.\n",
+			    modulefile);
+			exit(1);
+		}
 
-			/* config file */
-			milstr_ncat(modulefile, appname, sizeof(modulefile));
-			milstr_ncat(modulefile, "rc", sizeof(modulefile));
-			if ((stat(modulefile, &sb) >= 0)
-			 && !S_ISREG(sb.st_mode)) {
-				g_printerr("%s isn't regular file.\n",
-				    modulefile);
-			}
+		/* config file */
+		milstr_ncat(modulefile, appname, sizeof(modulefile));
+		milstr_ncat(modulefile, "rc", sizeof(modulefile));
+		if ((stat(modulefile, &sb) >= 0)
+		 && !S_ISREG(sb.st_mode)) {
+			g_printerr("%s isn't regular file.\n",
+			    modulefile);
 		}
 	}
 	if (modulefile[0] != '\0') {


### PR DESCRIPTION
This doesn’t change the default configuration directory, except when the user defined `$XDG_CONFIG_HOME` manually in the environment. This patch is best viewed in `git diff -w` to ignore indentation changes.

The other patch prevents the creation of the configuration directory on the build computer, which is useful for packages in distributions.