### PR TITLE
(libretro) Fix crash when loaded with no content.

### DIFF
--- a/sdl2/libretro/libretro.c
+++ b/sdl2/libretro/libretro.c
@@ -1386,7 +1386,8 @@ bool retro_load_game(const struct retro_game_info *game)
    bool worked = environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &syspath);
    if(!worked)abort();
 
-   extract_directory(base_dir, game->path, sizeof(base_dir));
+   if(game != NULL)
+      extract_directory(base_dir, game->path, sizeof(base_dir));
 
    strcpy(np2path, syspath);
    lr_init = 1;


### PR DESCRIPTION
When the libretro core is loaded without content.
```
retroarch -L /path/to/np2kai_libretro.so
```
It will crash when it tries to get the content directory which does not exist.

This can be avoided by checking if the content exists and then not extracting the directory when it doesn't exist. It will then proceed to init np2kai and then show a black screen with several `??????`. This matches the behavior when loaded with incorrect content (i.e. a text file).

Also see this PR which is discussing similar issues for other libretro cores.

https://github.com/libretro/RetroArch/pull/7102