### PR TITLE
win32 libretro build fixes

### DIFF
--- a/sdl2/dosio.c
+++ b/sdl2/dosio.c
@@ -187,7 +187,7 @@ short file_rename(const char *existpath, const char *newpath) {
 short file_dircreate(const char *path) {
 
 #if !(defined(__LIBRETRO__) && defined(VITA))
-#if defined(WIN32) && (!defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#if (defined(__LIBRETRO__) && defined(_WIN32)) || (defined(WIN32) && (!defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)))
 	return((short)mkdir(path));
 #else
 	return((short)mkdir(path, 0777));
@@ -199,7 +199,6 @@ short file_dirdelete(const char *path) {
 
 	return((short)rmdir(path));
 }
-
 
 /* カレントファイル操作 */
 void file_setcd(const char *exepath) {

--- a/sdl2/libretro/compiler.h
+++ b/sdl2/libretro/compiler.h
@@ -240,7 +240,9 @@ typedef SINT32	FILELEN;
 //#define UINT32_TO_PTR(v)	GUINT_TO_POINTER((UINT32)(v))
 
 //outdated things to ignore
+#if !defined(FASTCALL)
 #define	FASTCALL
+#endif
 #define	CPUCALL
 #define	MEMCALL
 #define	DMACCALL


### PR DESCRIPTION
These are some windows 64-bit and 32-bit build fixes for the libretro port, I do not use windows so I tested this in the libretro fork with the buildbot where the builds succeeded.

Please see https://github.com/libretro/NP2kai/pull/3, https://github.com/libretro/NP2kai/pull/4 and https://github.com/libretro/NP2kai/pull/5.

These are the build errors for reference.

Build failure
```
../sdl2/dosio.c: In function 'file_dircreate':

../sdl2/dosio.c:193:16: error: too many arguments to function 'mkdir'

  return((short)mkdir(path, 0777));

                ^~~~~

In file included from ../sdl2/libretro/libretro-common/include/retro_dirent.h:41:0,

                 from ../sdl2/dosio.c:10:

C:/msys64/mingw32/i686-w64-mingw32/include/direct.h:59:15: note: declared here

   int __cdecl mkdir(const char *_Path) __MINGW_ATTRIB_DEPRECATED_MSVC2005;

               ^~~~~

make: *** [Makefile.libretro:326: ../sdl2/dosio.o] Error 1
```
Warnings.
```
In file included from ../sound/fmgen/fmgen_types.h:4:0,

                 from ../sound/fmgen/fmgen_fmgen.h:10,

                 from ../sound/fmgen/fmgen_opm.h:10,

                 from ../sound/fmgen/fmgen_opm.cpp:9:

../sdl2/libretro/compiler.h:243:0: warning: "FASTCALL" redefined

 #define FASTCALL

 

In file included from C:/msys64/mingw32/i686-w64-mingw32/include/minwindef.h:163:0,

                 from C:/msys64/mingw32/i686-w64-mingw32/include/windef.h:8,

                 from C:/msys64/mingw32/i686-w64-mingw32/include/windows.h:69,

                 from ../sdl2/libretro/compiler.h:35,

                 from ../sound/fmgen/fmgen_types.h:4,

                 from ../sound/fmgen/fmgen_fmgen.h:10,

                 from ../sound/fmgen/fmgen_opm.h:10,

                 from ../sound/fmgen/fmgen_opm.cpp:9:

C:/msys64/mingw32/i686-w64-mingw32/include/winnt.h:262:0: note: this is the location of the previous definition

 #define FASTCALL __fastcall
```