### PR TITLE
Typo fix for install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ or
 
 ３． Install NP2kai.  
 
-	$ sudo -f Makefile.unix install
+	$ sudo make -f Makefile.unix install
 
 or
 
-	$ sudo -f Makefile21.unix install
+	$ sudo make -f Makefile21.unix install
 
 or
 	GCW Zero (GCW0) game device only


### PR DESCRIPTION
The 'make' part of the command was missing.