### PR TITLE
fix a mistake of DataSave function usage

### DIFF
--- a/sound/fmgen/fmgen_opna.cpp
+++ b/sound/fmgen/fmgen_opna.cpp
@@ -2052,7 +2052,7 @@ void OPNB::DataSave(struct OPNBData* data, void* adpcmadata) {
 
 // ---------------------------------------------------------------------------
 void OPNB::DataLoad(struct OPNBData* data, void* adpcmadata) {
-	OPNABase::DataSave(&data->opnabase);
+	OPNABase::DataLoad(&data->opnabase);
 	if(data->adpcmasize) {
 		adpcmabuf = (uint8*)malloc(data->adpcmasize);
 		memcpy(adpcmabuf, adpcmadata, data->adpcmasize);


### PR DESCRIPTION
I believe to have encountered a programming error in OPN chip source.
It's a mistake between `DataLoad` and `DataSave` function usage.