### PR TITLE
New core options with some sublabels.

### DIFF
--- a/sdl2/libretro/libretro-common/include/libretro.h
+++ b/sdl2/libretro/libretro-common/include/libretro.h
@@ -202,6 +202,8 @@ extern "C" {
 #define RETRO_DEVICE_ID_JOYPAD_L3      14
 #define RETRO_DEVICE_ID_JOYPAD_R3      15
 
+#define RETRO_DEVICE_ID_JOYPAD_MASK    256
+
 /* Index / Id values for ANALOG device. */
 #define RETRO_DEVICE_INDEX_ANALOG_LEFT       0
 #define RETRO_DEVICE_INDEX_ANALOG_RIGHT      1
@@ -248,6 +250,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_POINTER_X         0
 #define RETRO_DEVICE_ID_POINTER_Y         1
 #define RETRO_DEVICE_ID_POINTER_PRESSED   2
+#define RETRO_DEVICE_ID_POINTER_COUNT     3
 
 /* Returned from retro_get_region(). */
 #define RETRO_REGION_NTSC  0
@@ -274,6 +277,7 @@ enum retro_language
    RETRO_LANGUAGE_VIETNAMESE          = 15,
    RETRO_LANGUAGE_ARABIC              = 16,
    RETRO_LANGUAGE_GREEK               = 17,
+   RETRO_LANGUAGE_TURKISH             = 18,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -485,11 +489,13 @@ enum retro_mod
 /* Environment commands. */
 #define RETRO_ENVIRONMENT_SET_ROTATION  1  /* const unsigned * --
                                             * Sets screen rotation of graphics.
-                                            * Is only implemented if rotation can be accelerated by hardware.
                                             * Valid values are 0, 1, 2, 3, which rotates screen by 0, 90, 180,
                                             * 270 degrees counter-clockwise respectively.
                                             */
 #define RETRO_ENVIRONMENT_GET_OVERSCAN  2  /* bool * --
+                                            * NOTE: As of 2019 this callback is considered deprecated in favor of
+                                            * using core options to manage overscan in a more nuanced, core-specific way.
+                                            *
                                             * Boolean value whether or not the implementation should use overscan,
                                             * or crop away overscan.
                                             */
@@ -608,7 +614,7 @@ enum retro_mod
                                             * Afterward it may be called again for the core to communicate
                                             * updated options to the frontend, but the number of core
                                             * options must not change from the number in the initial call.
-					    *
+                                            *
                                             * 'data' points to an array of retro_variable structs
                                             * terminated by a { NULL, NULL } element.
                                             * retro_variable::key should be namespaced to not collide
@@ -1079,10 +1085,173 @@ enum retro_mod
                                             * fastforwarding mode.
                                             */
 
+#define RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE (50 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* float * --
+                                            * Float value that lets us know what target refresh rate 
+                                            * is curently in use by the frontend.
+                                            *
+                                            * The core can use the returned value to set an ideal 
+                                            * refresh rate/framerate.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_INPUT_BITMASKS (51 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                            /* bool * --
+                                            * Boolean value that indicates whether or not the frontend supports
+                                            * input bitmasks being returned by retro_input_state_t. The advantage
+                                            * of this is that retro_input_state_t has to be only called once to 
+                                            * grab all button states instead of multiple times.
+                                            *
+                                            * If it returns true, you can pass RETRO_DEVICE_ID_JOYPAD_MASK as 'id'
+                                            * to retro_input_state_t (make sure 'device' is set to RETRO_DEVICE_JOYPAD).
+                                            * It will return a bitmask of all the digital buttons.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION 52
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the core options
+                                            * interface supported by the frontend. If callback return false,
+                                            * API version is assumed to be 0.
+                                            *
+                                            * In legacy code, core options are set by passing an array of
+                                            * retro_variable structs to RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This may be still be done regardless of the core options
+                                            * interface version.
+                                            *
+                                            * If version is 1 however, core options may instead be set by
+                                            * passing an array of retro_core_option_definition structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS, or a 2D array of
+                                            * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
+                                            * This allows the core to additionally set option sublabel information
+                                            * and/or provide localisation support.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
+                                           /* const struct retro_core_option_definition ** --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
+                                            * returns an API version of 1.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            *
+                                            * 'data' points to an array of retro_core_option_definition structs
+                                            * terminated by a { NULL, NULL, NULL, {{0}}, NULL } element.
+                                            * retro_core_option_definition::key should be namespaced to not collide
+                                            * with other implementations' keys. e.g. A core called
+                                            * 'foo' should use keys named as 'foo_option'.
+                                            * retro_core_option_definition::desc should contain a human readable
+                                            * description of the key.
+                                            * retro_core_option_definition::info should contain any additional human
+                                            * readable information text that a typical user may need to
+                                            * understand the functionality of the option.
+                                            * retro_core_option_definition::values is an array of retro_core_option_value
+                                            * structs terminated by a { NULL, NULL } element.
+                                            * > retro_core_option_definition::values[index].value is an expected option
+                                            *   value.
+                                            * > retro_core_option_definition::values[index].label is a human readable
+                                            *   label used when displaying the value on screen. If NULL,
+                                            *   the value itself is used.
+                                            * retro_core_option_definition::default_value is the default core option
+                                            * setting. It must match one of the expected option values in the
+                                            * retro_core_option_definition::values array. If it does not, or the
+                                            * default value is NULL, the first entry in the
+                                            * retro_core_option_definition::values array is treated as the default.
+                                            *
+                                            * The number of possible options should be very limited,
+                                            * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * First entry should be treated as a default.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     "Provides increased performance at the expense of reduced accuracy",
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL 54
+                                           /* const struct retro_core_options_intl * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
+                                            * returns an API version of 1.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            *
+                                            * This is fundamentally the same as RETRO_ENVIRONMENT_SET_CORE_OPTIONS,
+                                            * with the addition of localisation support. The description of the
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS callback should be consulted
+                                            * for further details.
+                                            *
+                                            * 'data' points to a retro_core_options_intl struct.
+                                            *
+                                            * retro_core_options_intl::us is a pointer to an array of
+                                            * retro_core_option_definition structs defining the US English
+                                            * core options implementation. It must point to a valid array.
+                                            *
+                                            * retro_core_options_intl::local is a pointer to an array of
+                                            * retro_core_option_definition structs defining core options for
+                                            * the current frontend language. It may be NULL (in which case
+                                            * retro_core_options_intl::us is used by the frontend). Any items
+                                            * missing from this array will be read from retro_core_options_intl::us
+                                            * instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_intl::us array. Any default values in
+                                            * retro_core_options_intl::local array will be ignored.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY 55
+                                           /* struct retro_core_option_display * --
+                                            *
+                                            * Allows an implementation to signal the environment to show
+                                            * or hide a variable when displaying core options. This is
+                                            * considered a *suggestion*. The frontend is free to ignore
+                                            * this callback, and its implementation not considered mandatory.
+                                            *
+                                            * 'data' points to a retro_core_option_display struct
+                                            *
+                                            * retro_core_option_display::key is a variable identifier
+                                            * which has already been set by SET_VARIABLES/SET_CORE_OPTIONS.
+                                            *
+                                            * retro_core_option_display::visible is a boolean, specifying
+                                            * whether variable should be displayed
+                                            *
+                                            * Note that all core option variables will be set visible by
+                                            * default when calling SET_VARIABLES/SET_CORE_OPTIONS.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
- * File paths passed as parameters when using this api shall be well formed unix-style,
+ * File paths passed as parameters when using this API shall be well formed UNIX-style,
  * using "/" (unquoted forward slash) as directory separator regardless of the platform's native separator.
  * Paths shall also include at least one forward slash ("game.bin" is an invalid path, use "./game.bin" instead).
  * Other than the directory separator, cores shall not make assumptions about path format:
@@ -2322,6 +2491,64 @@ struct retro_variable
 
    /* Value to be obtained. If key does not exist, it is set to NULL. */
    const char *value;
+};
+
+struct retro_core_option_display
+{
+   /* Variable to configure in RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY */
+   const char *key;
+
+   /* Specifies whether variable should be displayed
+    * when presenting core options to the user */
+   bool visible;
+};
+
+/* Maximum number of values permitted for a core option
+ * NOTE: This may be increased on a core-by-core basis
+ * if required (doing so has no effect on the frontend) */
+#define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
+
+struct retro_core_option_value
+{
+   /* Expected option value */
+   const char *value;
+
+   /* Human-readable value label. If NULL, value itself
+    * will be displayed by the frontend */
+   const char *label;
+};
+
+struct retro_core_option_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE. */
+   const char *key;
+
+   /* Human-readable core option description (used as menu label) */
+   const char *desc;
+
+   /* Human-readable core option information (used as menu sublabel) */
+   const char *info;
+
+   /* Array of retro_core_option_value structs, terminated by NULL */
+   struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
+};
+
+struct retro_core_options_intl
+{
+   /* Pointer to an array of retro_core_option_definition structs
+    * - US English implementation
+    * - Must point to a valid array */
+   struct retro_core_option_definition *us;
+
+   /* Pointer to an array of retro_core_option_definition structs
+    * - Implementation for current frontend language
+    * - May be NULL */
+   struct retro_core_option_definition *local;
 };
 
 struct retro_game_info

--- a/sdl2/libretro/libretro.c
+++ b/sdl2/libretro/libretro.c
@@ -14,6 +14,7 @@
 
 #include "libretro.h"
 #include "libretro_params.h"
+#include "libretro_core_options.h"
 
 #include "compiler.h"//required to prevent missing type errors
 #include "beep.h"
@@ -843,56 +844,6 @@ void retro_set_environment(retro_environment_t cb)
    //bool no_rom = !LR_REQUIRESROM;
    //environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_rom);
 
-   struct retro_variable variables[] = {
-      { "np2kai_drive" , "Swap Disks on Drive; FDD2|FDD1" },
-      { "np2kai_keyboard" , "Keyboard (Restart); Ja|Us" },
-      { "np2kai_model" , "PC Model (Restart); PC-9801VX|PC-286|PC-9801VM" },
-      { "np2kai_clk_base" , "CPU Base Clock (Restart); 2.4576 MHz|1.9968 MHz" },
-      { "np2kai_clk_mult" , "CPU Clock Multiplier (Restart); 4|5|6|8|10|12|16|20|24|30|36|40|42|52|64|76|88|100|2" },
-#if defined(SUPPORT_ASYNC_CPU)
-      { "np2kai_async_cpu" , "Async CPU(experimental) (Restart); OFF|ON" },
-#endif
-      { "np2kai_ExMemory" , "RAM Size (Restart); 3|7|11|13|16|32|64|120|230|1" },
-      { "np2kai_FastMC" , "Fast memcheck; OFF|ON" },
-      { "np2kai_gdc" , "GDC; uPD7220|uPD72020" },
-      { "np2kai_skipline" , "Skipline Revisions; Full 255 lines|ON|OFF" },
-      { "np2kai_realpal" , "Real Palettes; OFF|ON" },
-      { "np2kai_lcd" , "LCD; OFF|ON" },
-      { "np2kai_SNDboard" , "Sound Board (Restart); PC9801-86|PC9801-26K + 86|PC9801-86 + Chibi-oto|PC9801-118|PC9801-86 + Mate-X PCM(B460)|PC9801-86 + 118|Mate-X PCM(B460)|Chibi-oto|Speak Board|PC9801-86 + Speak Board|Spark Board|Sound Orchestra|Sound Orchestra-V|Sound Blaster 16|AMD-98|Otomi-chanx2|Otomi-chanx2 + 86|None|PC9801-14|PC9801-26K" },
-      { "np2kai_118ROM" , "enable 118 ROM; ON|OFF" },
-      { "np2kai_jast_snd" , "JastSound; OFF|ON" },
-      { "np2kai_xroll" , "Swap PageUp/PageDown; ON|OFF" },
-      { "np2kai_usefmgen" , "Sound Generator; fmgen|Default" },
-      { "np2kai_volume_M" , "Volume Master; 100|0|5|10|15|20|25|30|35|40|45|50|55|60|65|70|75|80|85|90|95" },
-      { "np2kai_volume_F" , "Volume FM; 64|68|72|76|80|84|88|92|96|100|104|108|112|116|120|124|128|0|4|8|12|16|20|24|28|32|36|40|44|48|52|56|60" },
-      { "np2kai_volume_S" , "Volume SSG; 64|68|72|76|80|84|88|92|96|100|104|108|112|116|120|124|128|0|4|8|12|16|20|24|28|32|36|40|44|48|52|56|60" },
-      { "np2kai_volume_A" , "Volume ADPCM; 64|68|72|76|80|84|88|92|96|100|104|108|112|116|120|124|128|0|4|8|12|16|20|24|28|32|36|40|44|48|52|56|60" },
-      { "np2kai_volume_P" , "Volume PCM; 64|68|72|76|80|84|88|92|96|100|104|108|112|116|120|124|128|0|4|8|12|16|20|24|28|32|36|40|44|48|52|56|60" },
-      { "np2kai_volume_R" , "Volume RHYTHM; 64|68|72|76|80|84|88|92|96|100|104|108|112|116|120|124|128|0|4|8|12|16|20|24|28|32|36|40|44|48|52|56|60" },
-      { "np2kai_volume_C" , "Volume CD-DA; 128|136|144|154|160|168|196|184|192|200|208|216|224|232|240|248|255|0|8|16|24|32|40|48|56|64|72|80|88|96|104|112|120" },
-      { "np2kai_Seek_Snd" , "Floppy Seek Sound; OFF|ON" },
-      { "np2kai_Seek_Vol" , "Volume Floppy Seek; 80|84|88|92|96|100|104|108|112|116|120|124|128|0|4|8|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76" },
-      { "np2kai_BEEP_vol" , "Volume Beep; 3|0|1|2" },
-#if defined(SUPPORT_WAB)
-      { "np2kai_CLGD_en" , "Enable WAB (Restart App); OFF|ON" },
-      { "np2kai_CLGD_type" , "WAB Type; PC-9821Xe10,Xa7e,Xb10 built-in|PC-9821Bp,Bs,Be,Bf built-in|PC-9821Xe built-in|PC-9821Cb built-in|PC-9821Cf built-in|PC-9821Cb2 built-in|PC-9821Cx2 built-in|PC-9821 PCI CL-GD5446 built-in|MELCO WAB-S|MELCO WSN-A2F|MELCO WSN-A4F|I-O DATA GA-98NBI/C|I-O DATA GA-98NBII|I-O DATA GA-98NBIV|PC-9801-96(PC-9801B3-E02)|Auto Select(Xe10, GA-98NBI/C), PCI|Auto Select(Xe10, GA-98NBII), PCI|Auto Select(Xe10, GA-98NBIV), PCI|Auto Select(Xe10, WAB-S), PCI|Auto Select(Xe10, WSN-A2F), PCI|Auto Select(Xe10, WSN-A4F), PCI|Auto Select(Xe10, WAB-S)|Auto Select(Xe10, WSN-A2F)|Auto Select(Xe10, WSN-A4F)" },
-      { "np2kai_CLGD_fc" , "Use Fake Hardware Cursor; OFF|ON" },
-#endif	/* defined(SUPPORT_WAB) */
-#if defined(SUPPORT_PEGC)
-       { "np2kai_PEGC" , "Enable PEGC plane mode; ON|OFF" },
-#endif
-#if defined(SUPPORT_PCI)
-      { "np2kai_PCI_en" , "Enable PCI (Restart App); OFF|ON" },
-      { "np2kai_PCI_type" , "PCMC Type; Intel 82434LX|Intel 82441FX|VLSI Wildcat" },
-      { "np2kai_PCI_bios32" , "Use BIOS32 (not recommended); OFF|ON" },
-#endif	/* defined(SUPPORT_PCI) */
-      { "np2kai_usecdecc" , "Use CD-ROM EDC/ECC Emulation; ON|OFF" },
-      { "np2kai_j2msuratio" , "J2M Cursor Speed up Ratio; x10|x20|up stop|x5" },
-      { "np2kai_joy2mousekey" , "Joypad to Mouse/Keyboard Mapping; OFF|Mouse|Arrows|Keypad|Manual" },
-      { "np2kai_joynp2menu" , "Joypad to NP2 menu Mapping; L2|R|R2|L3|R3|A|B|X|Y|Start|Select|OFF|L" },
-      { NULL, NULL },
-   };
-
    environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &allow_no_game);
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &logging))
@@ -900,7 +851,7 @@ void retro_set_environment(retro_environment_t cb)
    else
       log_cb = NULL;
 
-   cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+   libretro_set_core_options(environ_cb);
 }
 
 static void update_variables(void)

--- a/sdl2/libretro/libretro_core_options.h
+++ b/sdl2/libretro/libretro_core_options.h
@@ -1,0 +1,1010 @@
+#ifndef LIBRETRO_CORE_OPTIONS_H__
+#define LIBRETRO_CORE_OPTIONS_H__
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+#include <retro_inline.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_ENGLISH */
+
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
+
+struct retro_core_option_definition option_defs_us[] = {
+   {
+      "np2kai_drive",
+      "Swap Disks on Drive",
+      NULL,
+      {
+         { "FDD1", NULL },
+         { "FDD2", NULL },
+         { NULL, NULL},
+      },
+      "FDD2"
+   },
+   {
+      "np2kai_keyboard",
+      "Keyboard (Restart)",
+      "Japanese or US keyboard type.",
+      {
+         { "Ja", NULL },
+         { "Us", NULL },
+         { NULL, NULL},
+      },
+      "Ja"
+   },
+   {
+      "np2kai_model",
+      "PC Model (Restart)",
+      NULL,
+      {
+
+         { "PC-286", NULL },
+         { "PC-9801VM", NULL },
+         { "PC-9801VX", NULL },
+         { NULL, NULL},
+      },
+      "PC-9801VX"
+   },
+   {
+      "np2kai_clk_base",
+      "CPU Base Clock (Restart)",
+      NULL,
+      {
+         { "1.9968 MHz", NULL },
+         { "2.4576 MHz", NULL },
+         { NULL, NULL},
+      },
+      "2.4576 MHz"
+   },
+   {
+      "np2kai_clk_mult",
+      "CPU Clock Multiplier (Restart)",
+      "Higher values require a fast machine. Can make some games run too fast.",
+      {
+         { "2", NULL },
+         { "4", NULL },
+         { "5", NULL },
+         { "6", NULL },
+         { "8", NULL },
+         { "10", NULL },
+         { "12", NULL },
+         { "16", NULL },
+         { "20", NULL },
+         { "24", NULL },
+         { "30", NULL },
+         { "36", NULL },
+         { "40", NULL },
+         { "42", NULL },
+         { "52", NULL },
+         { "64", NULL },
+         { "76", NULL },
+         { "88", NULL },
+         { "100", NULL },
+         { NULL, NULL},
+      },
+      "4"
+   },
+#if defined(SUPPORT_ASYNC_CPU)
+   {
+      "np2kai_async_cpu",
+      "Async CPU(experimental) (Restart)",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+#endif
+   {
+      "np2kai_ExMemory",
+      "RAM Size (Restart)",
+      "Amount of memory the virtual machine can use. Save states size will grow accordingly.",
+      {
+         { "1", NULL },
+         { "3", NULL },
+         { "7", NULL },
+         { "11", NULL },
+         { "13", NULL },
+         { "16", NULL },
+         { "32", NULL },
+         { "64", NULL },
+         { "120", NULL },
+         { "230", NULL },
+         { NULL, NULL},
+      },
+      "3"
+   },
+   {
+      "np2kai_FastMC",
+      "Fast memcheck",
+      "Do a faster memory checking at startup.",
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_gdc",
+      "GDC",
+      "Graphic Display Controller model.",
+      {
+         { "uPD7220", NULL },
+         { "uPD72020", NULL },
+         { NULL, NULL},
+      },
+      "uPD7220"
+   },
+   {
+      "np2kai_skipline",
+      "Skipline Revisions",
+      "'Off' will show black scanlines in older games.",
+      {
+         { "Full 255 lines", NULL },
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "Full 255 lines"
+   },
+   {
+      "np2kai_realpal",
+      "Real Palettes",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_lcd",
+      "LCD",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_SNDboard",
+      "Sound Board (Restart)",
+      NULL,
+      {
+         { "PC9801-14", NULL },
+         { "PC9801-86", NULL },
+         { "PC9801-86 + 118", NULL },
+         { "PC9801-86 + Mate-X PCM(B460)", NULL },
+         { "PC9801-86 + Chibi-oto", NULL },
+         { "PC9801-86 + Speak Board", NULL },
+         { "PC9801-26K", NULL },
+         { "PC9801-26K + 86", NULL },
+         { "PC9801-118", NULL },
+         { "Mate-X PCM(B460)", NULL },
+         { "Chibi-oto", NULL },
+         { "Speak Board", NULL },
+         { "Spark Board", NULL },
+         { "Sound Orchestra", NULL },
+         { "Sound Orchestra-V", NULL },
+         { "Sound Blaster 16", NULL },
+         { "AMD-98", NULL },
+         { "Otomi-chanx2", NULL },
+         { "Otomi-chanx2 + 86", NULL },
+         { "None", NULL },
+         { NULL, NULL},
+      },
+      "PC9801-86"
+   },
+   {
+      "np2kai_118ROM",
+      "enable 118 ROM",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "ON"
+   },
+   {
+      "np2kai_jast_snd",
+      "JastSound",
+      "Enable Jast Sound PCM device.",
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_xroll",
+      "Swap PageUp/PageDown",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "ON"
+   },
+   {
+      "np2kai_usefmgen",
+      "Sound Generator",
+      "Use 'fmgen' for enhanced sound rendering.",
+      {
+         { "Default", NULL },
+         { "fmgen", NULL },
+         { NULL, NULL},
+      },
+      "fmgen"
+   },
+   {
+      "np2kai_volume_M",
+      "Volume Master",
+      NULL,
+      {
+         { "0", NULL },
+         { "5", NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { "35", NULL },
+         { "40", NULL },
+         { "45", NULL },
+         { "50", NULL },
+         { "55", NULL },
+         { "60", NULL },
+         { "65", NULL },
+         { "70", NULL },
+         { "75", NULL },
+         { "80", NULL },
+         { "85", NULL },
+         { "90", NULL },
+         { "95", NULL },
+         { "100", NULL },
+         { NULL, NULL},
+      },
+      "100"
+   },
+   {
+      "np2kai_volume_F",
+      "Volume FM",
+      NULL,
+      {
+         { "0", NULL },
+         { "4", NULL },
+         { "8", NULL },
+         { "12", NULL },
+         { "16", NULL },
+         { "20", NULL },
+         { "24", NULL },
+         { "28", NULL },
+         { "32", NULL },
+         { "36", NULL },
+         { "40", NULL },
+         { "44", NULL },
+         { "48", NULL },
+         { "52", NULL },
+         { "56", NULL },
+         { "60", NULL },
+         { "64", NULL },
+         { "68", NULL },
+         { "72", NULL },
+         { "76", NULL },
+         { "80", NULL },
+         { "84", NULL },
+         { "88", NULL },
+         { "92", NULL },
+         { "96", NULL },
+         { "100", NULL },
+         { "104", NULL },
+         { "108", NULL },
+         { "112", NULL },
+         { "116", NULL },
+         { "120", NULL },
+         { "124", NULL },
+         { "128", NULL },
+         { NULL, NULL},
+      },
+      "64"
+   },
+   {
+      "np2kai_volume_S",
+      "Volume SSG",
+      NULL,
+      {
+         { "0", NULL },
+         { "4", NULL },
+         { "8", NULL },
+         { "12", NULL },
+         { "16", NULL },
+         { "20", NULL },
+         { "24", NULL },
+         { "28", NULL },
+         { "32", NULL },
+         { "36", NULL },
+         { "40", NULL },
+         { "44", NULL },
+         { "48", NULL },
+         { "52", NULL },
+         { "56", NULL },
+         { "60", NULL },
+         { "64", NULL },
+         { "68", NULL },
+         { "72", NULL },
+         { "76", NULL },
+         { "80", NULL },
+         { "84", NULL },
+         { "88", NULL },
+         { "92", NULL },
+         { "96", NULL },
+         { "100", NULL },
+         { "104", NULL },
+         { "108", NULL },
+         { "112", NULL },
+         { "116", NULL },
+         { "120", NULL },
+         { "124", NULL },
+         { "128", NULL },
+         { NULL, NULL},
+      },
+      "64"
+   },
+   {
+      "np2kai_volume_A",
+      "Volume ADPCM",
+      NULL,
+      {
+         { "0", NULL },
+         { "4", NULL },
+         { "8", NULL },
+         { "12", NULL },
+         { "16", NULL },
+         { "20", NULL },
+         { "24", NULL },
+         { "28", NULL },
+         { "32", NULL },
+         { "36", NULL },
+         { "40", NULL },
+         { "44", NULL },
+         { "48", NULL },
+         { "52", NULL },
+         { "56", NULL },
+         { "60", NULL },
+         { "64", NULL },
+         { "68", NULL },
+         { "72", NULL },
+         { "76", NULL },
+         { "80", NULL },
+         { "84", NULL },
+         { "88", NULL },
+         { "92", NULL },
+         { "96", NULL },
+         { "100", NULL },
+         { "104", NULL },
+         { "108", NULL },
+         { "112", NULL },
+         { "116", NULL },
+         { "120", NULL },
+         { "124", NULL },
+         { "128", NULL },
+         { NULL, NULL},
+      },
+      "64"
+   },
+   {
+      "np2kai_volume_P",
+      "Volume PCM",
+      NULL,
+      {
+         { "0", NULL },
+         { "4", NULL },
+         { "8", NULL },
+         { "12", NULL },
+         { "16", NULL },
+         { "20", NULL },
+         { "24", NULL },
+         { "28", NULL },
+         { "32", NULL },
+         { "36", NULL },
+         { "40", NULL },
+         { "44", NULL },
+         { "48", NULL },
+         { "52", NULL },
+         { "56", NULL },
+         { "60", NULL },
+         { "64", NULL },
+         { "68", NULL },
+         { "72", NULL },
+         { "76", NULL },
+         { "80", NULL },
+         { "84", NULL },
+         { "88", NULL },
+         { "92", NULL },
+         { "96", NULL },
+         { "100", NULL },
+         { "104", NULL },
+         { "108", NULL },
+         { "112", NULL },
+         { "116", NULL },
+         { "120", NULL },
+         { "124", NULL },
+         { "128", NULL },
+         { NULL, NULL},
+      },
+      "64"
+   },
+   {
+      "np2kai_volume_R",
+      "Volume RHYTHM",
+      NULL,
+      {
+         { "0", NULL },
+         { "4", NULL },
+         { "8", NULL },
+         { "12", NULL },
+         { "16", NULL },
+         { "20", NULL },
+         { "24", NULL },
+         { "28", NULL },
+         { "32", NULL },
+         { "36", NULL },
+         { "40", NULL },
+         { "44", NULL },
+         { "48", NULL },
+         { "52", NULL },
+         { "56", NULL },
+         { "60", NULL },
+         { "64", NULL },
+         { "68", NULL },
+         { "72", NULL },
+         { "76", NULL },
+         { "80", NULL },
+         { "84", NULL },
+         { "88", NULL },
+         { "92", NULL },
+         { "96", NULL },
+         { "100", NULL },
+         { "104", NULL },
+         { "108", NULL },
+         { "112", NULL },
+         { "116", NULL },
+         { "120", NULL },
+         { "124", NULL },
+         { "128", NULL },
+         { NULL, NULL},
+      },
+      "64"
+   },
+   {
+      "np2kai_volume_C",
+      "Volume CD-DA",
+      NULL,
+      {
+         { "0", NULL },
+         { "8", NULL },
+         { "16", NULL },
+         { "24", NULL },
+         { "32", NULL },
+         { "40", NULL },
+         { "48", NULL },
+         { "56", NULL },
+         { "64", NULL },
+         { "72", NULL },
+         { "80", NULL },
+         { "88", NULL },
+         { "96", NULL },
+         { "104", NULL },
+         { "112", NULL },
+         { "120", NULL },
+         { "128", NULL },
+         { "136", NULL },
+         { "144", NULL },
+         { "154", NULL },
+         { "160", NULL },
+         { "168", NULL },
+         { "196", NULL },
+         { "184", NULL },
+         { "192", NULL },
+         { "200", NULL },
+         { "208", NULL },
+         { "216", NULL },
+         { "224", NULL },
+         { "232", NULL },
+         { "240", NULL },
+         { "248", NULL },
+         { "255", NULL },
+         { NULL, NULL},
+      },
+      "128"
+   },
+   {
+      "np2kai_Seek_Snd",
+      "Floppy Seek Sound",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_Seek_Vol",
+      "Volume Floppy Seek",
+      NULL,
+      {
+         { "0", NULL },
+         { "4", NULL },
+         { "8", NULL },
+         { "12", NULL },
+         { "16", NULL },
+         { "20", NULL },
+         { "24", NULL },
+         { "28", NULL },
+         { "32", NULL },
+         { "36", NULL },
+         { "40", NULL },
+         { "44", NULL },
+         { "48", NULL },
+         { "52", NULL },
+         { "56", NULL },
+         { "60", NULL },
+         { "64", NULL },
+         { "68", NULL },
+         { "72", NULL },
+         { "76", NULL },
+         { "80", NULL },
+         { "84", NULL },
+         { "88", NULL },
+         { "92", NULL },
+         { "96", NULL },
+         { "100", NULL },
+         { "104", NULL },
+         { "108", NULL },
+         { "112", NULL },
+         { "116", NULL },
+         { "120", NULL },
+         { "124", NULL },
+         { "128", NULL },
+         { NULL, NULL},
+      },
+      ""
+   },
+   {
+      "np2kai_BEEP_vol",
+      "Volume Beep",
+      NULL,
+      {
+         { "0", NULL },
+         { "1", NULL },
+         { "2", NULL },
+         { "3", NULL },
+         { NULL, NULL},
+      },
+      "3"
+   },
+#if defined(SUPPORT_WAB)
+   {
+      "np2kai_CLGD_en",
+      "Enable WAB (Restart App)",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_CLGD_type",
+      "WAB Type",
+      NULL,
+      {
+         { "PC-9821Xe10,Xa7e,Xb10 built-in", NULL },
+         { "PC-9821Bp,Bs,Be,Bf built-in", NULL },
+         { "PC-9821Xe built-in", NULL },
+         { "PC-9821Cb built-in", NULL },
+         { "PC-9821Cf built-in", NULL },
+         { "PC-9821Cb2 built-in", NULL },
+         { "PC-9821Cx2 built-in", NULL },
+         { "PC-9821 PCI CL-GD5446 built-in", NULL },
+         { "MELCO WAB-S", NULL },
+         { "MELCO WSN-A2F", NULL },
+         { "MELCO WSN-A4F", NULL },
+         { "I-O DATA GA-98NBI/C", NULL },
+         { "I-O DATA GA-98NBII", NULL },
+         { "I-O DATA GA-98NBIV", NULL },
+         { "PC-9801-96(PC-9801B3-E02)", NULL },
+         { "Auto Select(Xe10, GA-98NBI/C), PCI", NULL },
+         { "Auto Select(Xe10, GA-98NBII), PCI", NULL },
+         { "Auto Select(Xe10, GA-98NBIV), PCI", NULL },
+         { "Auto Select(Xe10, WAB-S), PCI", NULL },
+         { "Auto Select(Xe10, WSN-A2F), PCI", NULL },
+         { "Auto Select(Xe10, WSN-A4F), PCI", NULL },
+         { "Auto Select(Xe10, WAB-S)", NULL },
+         { "Auto Select(Xe10, WSN-A2F)", NULL },
+         { "Auto Select(Xe10, WSN-A4F)", NULL },
+         { NULL, NULL},
+      },
+      "PC-9821Xe10,Xa7e,Xb10 built-in"
+   },
+   {
+      "np2kai_CLGD_fc",
+      "Use Fake Hardware Cursor",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+#endif	/* defined(SUPPORT_WAB) */
+#if defined(SUPPORT_PEGC)
+   {
+      "np2kai_PEGC",
+      "Enable PEGC plane mode",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "ON"
+   },
+#endif
+#if defined(SUPPORT_PCI)
+   {
+      "np2kai_PCI_en",
+      "Enable PCI (Restart App)",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_PCI_type",
+      "PCMC Type",
+      NULL,
+      {
+         { "Intel 82434LX", NULL },
+         { "Intel 82441FX", NULL },
+         { "VLSI Wildcat", NULL },
+         { NULL, NULL},
+      },
+      "Intel 82434LX"
+   },
+   {
+      "np2kai_PCI_bios32",
+      "Use BIOS32 (not recommended)",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+#endif	/* defined(SUPPORT_PCI) */
+   {
+      "np2kai_usecdecc",
+      "Use CD-ROM EDC/ECC Emulation",
+      NULL,
+      {
+         { "OFF", NULL },
+         { "ON", NULL },
+         { NULL, NULL},
+      },
+      "ON"
+   },
+   {
+      "np2kai_j2msuratio",
+      "J2M Cursor Speed up Ratio",
+      NULL,
+      {
+         { "x5", NULL },
+         { "x10", NULL },
+         { "x20", NULL },
+         { "up stop", NULL },
+         { NULL, NULL},
+      },
+      "x10"
+   },
+   {
+      "np2kai_joy2mousekey",
+      "Joypad to Mouse/Keyboard Mapping",
+      "Emulate a keyboard or mouse on your gamepad. Map keyboard 'Arrows' or 'Keypad' on the D-pad.",
+      {
+         { "OFF", NULL },
+         { "Mouse", NULL },
+         { "Arrows", NULL },
+         { "Keypad", NULL },
+         { "Manual", NULL },
+         { NULL, NULL},
+      },
+      "OFF"
+   },
+   {
+      "np2kai_joynp2menu",
+      "Joypad to NP2 menu Mapping",
+      "Select a gamepad button to open NP2 Menu.",
+      {
+         { "OFF", NULL },
+         { "L", NULL },
+         { "L2", NULL },
+         { "L3", NULL },
+         { "R", NULL },
+         { "R2", NULL },
+         { "R3", NULL },
+         { "A", NULL },
+         { "B", NULL },
+         { "X", NULL },
+         { "Y", NULL },
+         { "Start", NULL },
+         { "Select", NULL },
+         { NULL, NULL},
+      },
+      "L2"
+   },
+   { NULL, NULL, NULL, {{0}}, NULL },
+};
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
+   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,           /* RETRO_LANGUAGE_JAPANESE */
+   NULL,           /* RETRO_LANGUAGE_FRENCH */
+   NULL,           /* RETRO_LANGUAGE_SPANISH */
+   NULL,           /* RETRO_LANGUAGE_GERMAN */
+   NULL,           /* RETRO_LANGUAGE_ITALIAN */
+   NULL,           /* RETRO_LANGUAGE_DUTCH */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,           /* RETRO_LANGUAGE_KOREAN */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,           /* RETRO_LANGUAGE_POLISH */
+   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,           /* RETRO_LANGUAGE_ARABIC */
+   NULL,           /* RETRO_LANGUAGE_GREEK */
+   NULL,           /* RETRO_LANGUAGE_TURKISH */
+};
+
+/*
+ ********************************
+ * Functions
+ ********************************
+*/
+
+/* Handles configuration/setting of core options.
+ * Should only be called inside retro_set_environment().
+ * > We place the function body in the header to avoid the
+ *   necessity of adding more .c files (i.e. want this to
+ *   be as painless as possible for core devs)
+ */
+
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+{
+   unsigned version = 0;
+
+   if (!environ_cb)
+      return;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+   {
+      struct retro_core_options_intl core_options_intl;
+      unsigned language = 0;
+
+      core_options_intl.us    = option_defs_us;
+      core_options_intl.local = NULL;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+         core_options_intl.local = option_defs_intl[language];
+
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+   }
+   else
+   {
+      size_t i;
+      size_t option_index              = 0;
+      size_t num_options               = 0;
+      struct retro_variable *variables = NULL;
+      char **values_buf                = NULL;
+
+      /* Determine number of options
+       * > Note: We are going to skip a number of irrelevant
+       *   core options when building the retro_variable array,
+       *   but we'll allocate space for all of them. The difference
+       *   in resource usage is negligible, and this allows us to
+       *   keep the code 'cleaner' */
+      while (true)
+      {
+         if (option_defs_us[num_options].key)
+            num_options++;
+         else
+            break;
+      }
+
+      /* Allocate arrays */
+      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
+      values_buf = (char **)calloc(num_options, sizeof(char *));
+
+      if (!variables || !values_buf)
+         goto error;
+
+      /* Copy parameters from option_defs_us array */
+      for (i = 0; i < num_options; i++)
+      {
+         const char *key                        = option_defs_us[i].key;
+         const char *desc                       = option_defs_us[i].desc;
+         const char *default_value              = option_defs_us[i].default_value;
+         struct retro_core_option_value *values = option_defs_us[i].values;
+         size_t buf_len                         = 3;
+         size_t default_index                   = 0;
+
+         values_buf[i] = NULL;
+
+         if (desc)
+         {
+            size_t num_values = 0;
+
+            /* Determine number of values */
+            while (true)
+            {
+               if (values[num_values].value)
+               {
+                  /* Check if this is the default value */
+                  if (default_value)
+                     if (strcmp(values[num_values].value, default_value) == 0)
+                        default_index = num_values;
+
+                  buf_len += strlen(values[num_values].value);
+                  num_values++;
+               }
+               else
+                  break;
+            }
+
+            /* Build values string */
+            if (num_values > 1)
+            {
+               size_t j;
+
+               buf_len += num_values - 1;
+               buf_len += strlen(desc);
+
+               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+               if (!values_buf[i])
+                  goto error;
+
+               strcpy(values_buf[i], desc);
+               strcat(values_buf[i], "; ");
+
+               /* Default value goes first */
+               strcat(values_buf[i], values[default_index].value);
+
+               /* Add remaining values */
+               for (j = 0; j < num_values; j++)
+               {
+                  if (j != default_index)
+                  {
+                     strcat(values_buf[i], "|");
+                     strcat(values_buf[i], values[j].value);
+                  }
+               }
+            }
+         }
+
+         variables[option_index].key   = key;
+         variables[option_index].value = values_buf[i];
+         option_index++;
+      }
+      
+      /* Set variables */
+      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+
+error:
+
+      /* Clean up */
+      if (values_buf)
+      {
+         for (i = 0; i < num_options; i++)
+         {
+            if (values_buf[i])
+            {
+               free(values_buf[i]);
+               values_buf[i] = NULL;
+            }
+         }
+
+         free(values_buf);
+         values_buf = NULL;
+      }
+
+      if (variables)
+      {
+         free(variables);
+         variables = NULL;
+      }
+   }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
New Libretro core options format.

It's compatible with older version of RetroArch.
It allows to add sublabels to explain your options:
![sublabels](https://user-images.githubusercontent.com/6266038/61476762-0a9ca900-a98e-11e9-8732-fd5ea1cb6b12.png)

Now you can order your lists as you want, the 1st item doesn't have to be the default value.
The new default is [like here](https://github.com/libretro/PokeMini/blob/master/libretro/libretro_core_options.h#L61).
![list-numbers](https://user-images.githubusercontent.com/6266038/61476897-551e2580-a98e-11e9-8439-cd66b40cdf3f.png)
![list-soundcards](https://user-images.githubusercontent.com/6266038/61476898-551e2580-a98e-11e9-9425-37175a2d07a3.png)

You can name your options as you wish and you can also translate them.
So you could now write them all in Japanese and they will show up following the RetroArch language setting.
[See translation example here.](https://github.com/libretro/PokeMini/blob/master/libretro/libretro_core_options.h#L185)

Sorry I could not do more sublabels as I don't understand all the options in NP2kai! :sweat_smile: 