### PR TITLE
Fixed some keycodes on SDL1 and SDL2 ports.

### DIFF
--- a/sdl/kbtrans.c
+++ b/sdl/kbtrans.c
@@ -501,7 +501,7 @@ static const SDLKCNV sdlcnv101[] = {
   {SDL_SCANCODE_RSHIFT,       0x75},  // RShift
   // Kana
   {SDL_SCANCODE_LGUI,         0x70},  // LSuper (M)
-  {SDL_SCANCODE_RCTRL,        0x33},  // GRPH
+  {SDL_SCANCODE_RCTRL,        0x73},  // GRPH
   {SDL_SCANCODE_LALT,         0x51},  // NFER
   {SDL_SCANCODE_SPACE,        0x34},  // Space
   {SDL_SCANCODE_RALT,         0x35},  // XFER
@@ -719,7 +719,7 @@ static const SDLKCNV sdlcnv106[] = {
   {SDL_SCANCODE_RSHIFT,         0x75},  // RShift
   // Kana
   {SDL_SCANCODE_LGUI,           0x70},  // LSuper (M)
-  {SDL_SCANCODE_RCTRL,          0x33},  // GRPH
+  {SDL_SCANCODE_RCTRL,          0x73},  // GRPH
   {SDL_SCANCODE_LALT,           0x51},  // NFER
   {SDL_SCANCODE_SPACE,          0x34},  // Space
   {SDL_SCANCODE_RALT,           0x35},  // XFER

--- a/sdl/kbtrans.c
+++ b/sdl/kbtrans.c
@@ -393,8 +393,8 @@ static const SDLKCNV sdlcnv101[] = {
   // _ _
   {SDLK_RSHIFT,       0x75},  // RShift
   // Kana
-  {SDLK_LSUPER,       0x70},  // LSuper (M)
-  {SDLK_RCTRL,        0x33},  // GRPH
+  {SDLK_LSUPER,       0x77},  // LSuper (M)
+  {SDLK_RCTRL,        0x73},  // GRPH
   {SDLK_LALT,         0x51},  // NFER
   {SDLK_SPACE,        0x34},  // Space
   {SDLK_RALT,         0x35},  // XFER
@@ -500,7 +500,7 @@ static const SDLKCNV sdlcnv101[] = {
   // _ _
   {SDL_SCANCODE_RSHIFT,       0x75},  // RShift
   // Kana
-  {SDL_SCANCODE_LGUI,         0x70},  // LSuper (M)
+  {SDL_SCANCODE_LGUI,         0x77},  // LSuper (M)
   {SDL_SCANCODE_RCTRL,        0x73},  // GRPH
   {SDL_SCANCODE_LALT,         0x51},  // NFER
   {SDL_SCANCODE_SPACE,        0x34},  // Space
@@ -611,8 +611,8 @@ static const SDLKCNV sdlcnv106[] = {
   // _ _
   {SDLK_RSHIFT,       0x75},  // RShift
   // Kana
-  {SDLK_LSUPER,       0x70},  // LSuper (M)
-  {SDLK_RCTRL,        0x33},  // GRPH
+  {SDLK_LSUPER,       0x77},  // LSuper (M)
+  {SDLK_RCTRL,        0x73},  // GRPH
   {SDLK_LALT,         0x51},  // NFER
   {SDLK_SPACE,        0x34},  // Space
   {SDLK_RALT,         0x35},  // XFER
@@ -718,7 +718,7 @@ static const SDLKCNV sdlcnv106[] = {
   {SDL_SCANCODE_INTERNATIONAL1, 0x33},  // _ _
   {SDL_SCANCODE_RSHIFT,         0x75},  // RShift
   // Kana
-  {SDL_SCANCODE_LGUI,           0x70},  // LSuper (M)
+  {SDL_SCANCODE_LGUI,           0x77},  // LSuper (M)
   {SDL_SCANCODE_RCTRL,          0x73},  // GRPH
   {SDL_SCANCODE_LALT,           0x51},  // NFER
   {SDL_SCANCODE_SPACE,          0x34},  // Space


### PR DESCRIPTION
SDL1、SDL2でGRPHキー、左WinキーのPC-9801でのキーコードが間違っていたのでなおしました。

The key code of the GRPH key and the left Win key with PC-9801 in SDL1 and SDL2 was wrong, so I fixed it.
