### PR TITLE
Fixed an error when building an SDL port with MSYS2 of Windows.

### DIFF
--- a/common/milstr.c
+++ b/common/milstr.c
@@ -297,7 +297,7 @@ int STRCALL milsjis_memncmp(const char *str, const char *cmp, unsigned int maxle
 		if(maxlen) {
 			maxlen--;
 		}
-	} while(s == c && cn);
+	} while(s == c && maxlen);
 	return((s > c)?1:-1);
 }
 


### PR DESCRIPTION
SDLポートをWindowsのMSYS2でビルドしてみたら、エラーになったので直してみました。
ただし、VS2019でビルドした場合はエラーにならないんで、SUPPORT_SJISが定義されているのがそもそも正しいのか？って疑問が。

When I build the SDL port with MSYS2 of Windows, I got an error, so I fixed it.
However, I didn't get an error then I build it with VS2019, so is it correct that SUPPORT_SJIS is defining? That's the question.