### PR TITLE
Fixed that hdrvroot and hdrv_acc are written twice in the configuration file.(SDL、X)

### DIFF
--- a/sdl/ini.c
+++ b/sdl/ini.c
@@ -590,9 +590,6 @@ static const INITBL iniitem[] = {
 	{OEMTEXT("bmap_Num"), INITYPE_UINT32,	&bmpfilenumber,		0},
 	{OEMTEXT("fontfile"), INITYPE_STR,	np2cfg.fontfile,	MAX_PATH},
 	{OEMTEXT("biospath"), INIRO_STR,		np2cfg.biospath,	MAX_PATH},
-	{OEMTEXT("hdrvroot"), INIRO_STR,		np2cfg.hdrvroot,	MAX_PATH},
-	{OEMTEXT("hdrv_acc"), INIRO_UINT8,	&np2cfg.hdrvacc,	0},
-
 #if defined(SUPPORT_HOSTDRV)
 	{OEMTEXT("use_hdrv"), INITYPE_BOOL,	&np2cfg.hdrvenable,	0},
 	{OEMTEXT("hdrvroot"), INITYPE_STR,	&np2cfg.hdrvroot,	MAX_PATH},

--- a/x/ini.c
+++ b/x/ini.c
@@ -584,9 +584,6 @@ static INITBL iniitem[] = {
 	{"bmap_Dir", INITYPE_STR,	bmpfilefolder,		MAX_PATH},
 	{"fontfile", INITYPE_STR,	np2cfg.fontfile,	MAX_PATH},
 	{"biospath", INIRO_STR,		np2cfg.biospath,	MAX_PATH},
-	{"hdrvroot", INIRO_STR,		np2cfg.hdrvroot,	MAX_PATH},
-	{"hdrv_acc", INIRO_UINT8,	&np2cfg.hdrvacc,	0},
-
 #if defined(SUPPORT_HOSTDRV)
 	{"use_hdrv", INITYPE_BOOL,	&np2cfg.hdrvenable,	0},
 	{"hdrvroot", INITYPE_STR,	&np2cfg.hdrvroot,	MAX_PATH},


### PR DESCRIPTION
SLD、Xポートで設定ファイルでhdrvroot、hdrv_accが2つずつ書き込まれているのをなおしてみた。

Fixed that hdrvroot and hdrv_acc were written twice in the configuration file on SLD and X-port.