### PR TITLE
Support for xcode12

### DIFF
--- a/network/net.c
+++ b/network/net.c
@@ -64,6 +64,8 @@
 
 #include <sys/time.h>
 
+unsigned GetTickCount();
+
 /*
 unsigned GetTickCount()
 {

--- a/sdl/dosio.c
+++ b/sdl/dosio.c
@@ -19,6 +19,7 @@
 #include <direct.h>
 #else
 #include <dirent.h>
+#include <unistd.h>
 #endif
 #endif
 

--- a/sdl/taskmng.c
+++ b/sdl/taskmng.c
@@ -1,4 +1,6 @@
+#if !defined(__APPLE__)
 #define _POSIX_C_SOURCE 199309L
+#endif
 #include	<compiler.h>
 #include	"inputmng.h"
 #include	"taskmng.h"


### PR DESCRIPTION
Xcode12をインストールしたmacOSでエラーになったので対応してみました。
#118 に書いたように_POSIX_C_SOURCEを宣言しているところが気になりますが、とりあえずプルリクエスト出しときます。

次の表のような感じでビルドとMS-DOSが動くところまでのテストを行ってみました。

SDL1-macOSは改修前のビルドでも正しく動作してない。

SDL1-Win(MSYS2 Biuld)は改修前のコードでもリンクエラーになった。

これらの問題は、また後でIssuesに書いておきます。実はどうやったら直るかよくわからない😅

|                        | Build | Test |
|------------------------|-------|------|
| SDL1-macOS             | ok    | NG   |
| SDL1-Linux             | ok    | ok   |
| SDL1-Win(MSYS2 Build)  | NG    |      |
| SDL2-macOS             | ok    | ok   |
| SDL2-Linux             | ok    | ok   |
| SDL2-Win(MSYS2 Build)  | ok    | ok   |
| Windows(VS2019 Build)  | ok    | ok   |
| X11-SDL1               | ok    | ok   |
| X11-SDL2               | ok    | ok   |
| libretro-macOS         | ok    | ok   |
| libretro-Linux         | ok    | ok   |
| libretro-Win           | ok    | ok   |
| libretro-Android       | ok    |      |
| libretro-iOS           | ok    |      |
| Emscripten             |       |      |
| OpenDingux             |       |      |

---

I fixed it because the error occurred on macOS where Xcode12 was installed.
As I wrote in #118, I'm worried about defining _POSIX_C_SOURCE, but I'll submit a pull request anyway.

I tested the build and MS-DOS to the point where it runs, as shown in the following table.

SDL1-macOS is not running normally even in the pre-modified build.

SDL1-Win (MSYS2 Biuld) had a link error even in the code before the modification.

I'll write about these issues later in Issues.　Actually, I'm not sure how to fix it 😅.

|                        | Build | Test |
|------------------------|-------|------|
| SDL1-macOS             | ok    | NG   |
| SDL1-Linux             | ok    | ok   |
| SDL1-Win(MSYS2 Build)  | NG    |      |
| SDL2-macOS             | ok    | ok   |
| SDL2-Linux             | ok    | ok   |
| SDL2-Win(MSYS2 Build)  | ok    | ok   |
| Windows(VS2019 Build)  | ok    | ok   |
| X11-SDL1               | ok    | ok   |
| X11-SDL2               | ok    | ok   |
| libretro-macOS         | ok    | ok   |
| libretro-Linux         | ok    | ok   |
| libretro-Win           | ok    | ok   |
| libretro-Android       | ok    |      |
| libretro-iOS           | ok    |      |
| Emscripten             |       |      |
| OpenDingux             |       |      |
