### PR TITLE
[Win] Fixed a problem with the filter of the file open dialog

### DIFF
--- a/codecnv/ucs4ucs2.c
+++ b/codecnv/ucs4ucs2.c
@@ -24,10 +24,14 @@ UINT codecnv_ucs4toucs2(UINT16 *lpOutput, UINT cchOutput, const UINT32 *lpInput,
 	UINT n = 0;
 	UINT nLength;
 
-	if(lpOutput != NULL && lpInput != NULL) {
-		if(cchOutput == 0) {
+	if(lpInput != NULL) {
+		if(!lpOutput || cchOutput == 0) {
 			lpOutput = NULL;
-			cchOutput = (UINT)-1;
+			if (cchInput == (UINT)-1) {
+				cchOutput = 0;
+			} else {
+				cchOutput = (UINT)-1;
+			}
 		}
 
 		if(cchInput != (UINT)-1) {
@@ -36,7 +40,9 @@ UINT codecnv_ucs4toucs2(UINT16 *lpOutput, UINT cchOutput, const UINT32 *lpInput,
 		} else {
 			// String mode
 			nLength = ucs4toucs2(lpOutput, cchOutput - 1, lpInput, codecnv_ucs4len(lpInput));
-			lpOutput[nLength] = '\0';
+			if (lpOutput) {
+				lpOutput[nLength] = '\0';
+			}
 			n = nLength + 1;
 		}
 	}
@@ -74,12 +80,16 @@ UINT codecnv_ucs4toucs2_1(UINT16 *lpOutput, UINT cchOutput, const UINT32 *lpInpu
 	}
 
 	if(lpInput[0] < 0x10000 && cchOutput > 1) {
-		lpOutput[0] = (UINT16)lpInput[0];
-		lpOutput[1] = 0;
+		if (lpOutput) {
+			lpOutput[0] = (UINT16)lpInput[0];
+			lpOutput[1] = 0;
+		}
 		n = 1;
 	} else if(cchOutput > 2) {
-		lpOutput[0] = (UINT16)((lpInput[0] - 0x10000) / 0x400 + 0xD800);
-		lpOutput[1] = (UINT16)((lpInput[0] - 0x10000) % 0x400 + 0xDC00);
+		if (lpOutput) {
+			lpOutput[0] = (UINT16)((lpInput[0] - 0x10000) / 0x400 + 0xD800);
+			lpOutput[1] = (UINT16)((lpInput[0] - 0x10000) % 0x400 + 0xDC00);
+		}
 		n = 2;
 	}
 
@@ -97,15 +107,20 @@ UINT codecnv_ucs4toucs2_1(UINT16 *lpOutput, UINT cchOutput, const UINT32 *lpInpu
 static UINT ucs4toucs2(UINT16 *lpOutput, UINT cchOutput, const UINT32 *lpInput, UINT cchInput) {
 	UINT nRemain;
 	UINT n = 1;
-
+	UINT len;
+	
+	len = 0;
 	nRemain = cchOutput;
 	while ((cchInput > 0) && (nRemain > 0) && (n > 0)) {
 		n = codecnv_ucs4toucs2_1(lpOutput, nRemain, lpInput);
-		lpOutput += n;
-		nRemain -= n;
+		if (lpOutput) {
+			lpOutput += n;
+			nRemain -= n;
+		}
+		len += n;
 		lpInput++;
 		cchInput--;
 	}
 
-	return (UINT)(cchOutput - nRemain);
+	return len;
 }

--- a/codecnv/utf8ucs2.c
+++ b/codecnv/utf8ucs2.c
@@ -24,10 +24,14 @@ UINT codecnv_utf8toucs2(UINT16 *lpOutput, UINT cchOutput, const char *lpInput, U
 	UINT n = 0;
 	UINT nLength;
 
-	if(lpOutput != NULL && lpInput != NULL) {
-		if(cchOutput == 0) {
+	if(lpInput != NULL) {
+		if(!lpOutput || cchOutput == 0) {
 			lpOutput = NULL;
-			cchOutput = (UINT)-1;
+			if (cchInput == -1) {
+				cchOutput = (UINT)-0;
+			} else {
+				cchOutput = (UINT)-1;
+			}
 		}
 
 		if(cchInput != (UINT)-1) {
@@ -36,7 +40,9 @@ UINT codecnv_utf8toucs2(UINT16 *lpOutput, UINT cchOutput, const char *lpInput, U
 		} else {
 			// String mode
 			nLength = utf8toucs2(lpOutput, cchOutput - 1, lpInput, (UINT)strlen(lpInput));
-			lpOutput[nLength] = '\0';
+			if (lpOutput) {
+				lpOutput[nLength] = '\0';
+			}
 			n = nLength + 1;
 		}
 	}
@@ -56,6 +62,7 @@ static UINT utf8toucs2(UINT16 *lpOutput, UINT cchOutput, const char *lpInput, UI
 	UINT n, m;
 	UINT nRemain;
 	UINT32 c[2];
+	UINT len = 0;
 
 	n = m = 1;
 	nRemain = cchOutput;
@@ -66,10 +73,13 @@ static UINT utf8toucs2(UINT16 *lpOutput, UINT cchOutput, const char *lpInput, UI
 			m = codecnv_ucs4toucs2(lpOutput, 2, c, 1);
 			lpInput += n;
 			cchInput -= n;
-			lpOutput += m;
-			nRemain -= m;
+			if (lpOutput) {
+				lpOutput += m;
+				nRemain -= m;
+			}
+			len += m;
 		}
 	}
 
-	return (UINT)(cchOutput - nRemain);
+	return len;
 }

--- a/windows/dialog/winfiledlg.c
+++ b/windows/dialog/winfiledlg.c
@@ -23,18 +23,32 @@ BOOL WinFileDialogW_MM(
   wchar_t wname[MAX_PATH];
   wchar_t wdefext[MAX_PATH];
   wchar_t wtitle[MAX_PATH];
-  wchar_t wfilter[MAX_PATH];
+  wchar_t *wfilter;
+  UINT len;
+
+  len = codecnv_utf8toucs2(NULL, 0, filter, -1);
+  wfilter = (wchar_t*)calloc(len, sizeof(wchar_t));
+  if (!wfilter) {
+      return FALSE;
+  }
 
   codecnv_utf8toucs2(wpath, MAX_PATH, path, -1);
   codecnv_utf8toucs2(wname, MAX_PATH, name, -1);
   codecnv_utf8toucs2(wdefext, MAX_PATH, defext, -1);
   codecnv_utf8toucs2(wtitle, MAX_PATH, title, -1);
-  codecnv_utf8toucs2(wfilter, MAX_PATH, filter, -1);
+  codecnv_utf8toucs2(wfilter, len, filter, -1);
 
+  for (UINT i = 0; i < len; i++) {
+      if (wfilter[i] == L'|') {
+          wfilter[i] = 0;
+      }
+  }
   res = WinFileDialogW_WW(hwnd, pofnw, mode, wpath, wname, wdefext, wtitle, wfilter, nFilterIndex);
 
   codecnv_ucs2toutf8(path, MAX_PATH, wpath, -1);
   codecnv_ucs2toutf8(name, MAX_PATH, wname, -1);
+
+  free(wfilter);
 
   return res;
 }


### PR DESCRIPTION
Windows(VS2019 build)でFDDやHDDのファイル選択ダイアログでフィルターコンボボックスの表示がおかしいのを改修してみたした。

たまたま見つけて比較的簡単に直せそうだったので直してみました。

## 不具合
フィルターコンボボックスがこのようになっていました。

![2020-10-06 (2)](https://user-images.githubusercontent.com/43332038/95225482-d03f5600-0836-11eb-827b-5e96f9a1038f.png)

## 原因
OPENFILENAMEW構造体のlpstrFilterに設定する値に問題があった。フィルター名とワイルドカードの区切りが'|’になっていた。区切りは'\0'が正しい。

## 変更点
1. ucs2に変換後のフィルターに設定する値の'|'を'\0'に変換する処理を入れた。
2. utf8からucs2に変換後の値を入れる配列変数が小さかったのでcallocで動的に確保するようにした。
3. 2.でucs2に変換後の文字数が必要だったのでcodecnv_utf8toucs2()で文字数を取得できるようにした。

ということで、よろしくお願いします。

↓英訳。相変わらず翻訳ツールの力を結構借りてます💦

---


The display of the filter combo box in the file open dialog of FDD and HDD on Windows (VS2019 build) was fixed.

I happened to find it and it seemed relatively easy to fix, so I fixed it.

## Problem

The filter combo box looked like this.

![2020-10-06 (2)](https://user-images.githubusercontent.com/43332038/95225482-d03f5600-0836-11eb-827b-5e96f9a1038f.png)

## Cause
There was a problem with the value set to lpstrFilter in the OPENFILENAMEW structure. The filter name and wildcards are separated by '|'. The right delimiter is '\0'.

## Changes
1. I added a process to convert '|' to '\0' in the filter string after conversion to ucs2.
2. The array for the converted value from utf8 to ucs2 was too small, so I used calloc to allocate memory dynamically.
3. I needed the number of characters after conversion to ucs2 in 2., so I used codecnv_utf8toucs2() to get the number of characters.So I changed codecnv_utf8toucs2() to get the number of characters.