### PR TITLE
 Fixed the right shift not working.

### DIFF
--- a/sdl/kbtrans.c
+++ b/sdl/kbtrans.c
@@ -87,7 +87,7 @@ static const LRKCNV lrcnv101[] = {
   {RETROK_PERIOD,       0x31},  // . >
   {RETROK_SLASH,        0x32},  // / ?
   // _ _
-  {RETROK_RSHIFT,       0x75},  // RShift
+  {RETROK_RSHIFT,       0x7d},  // RShift
   // Kana
   {RETROK_LSUPER,       0x77},  // LSuper
   {RETROK_RCTRL,        0x73},  // GRPH
@@ -197,7 +197,7 @@ static const LRKCNV lrcnv106[] = {
   {RETROK_PERIOD,       0x31},  // . >
   {RETROK_SLASH,        0x32},  // / ?
   {2,      0x33},       // _ _ (L2?menu open?)
-  {RETROK_RSHIFT,       0x75},  // RShift
+  {RETROK_RSHIFT,       0x7d},  // RShift
   // Kana
   {RETROK_LSUPER,       0x77},  // LSuper
   {RETROK_RCTRL,        0x73},  // GRPH
@@ -391,7 +391,7 @@ static const SDLKCNV sdlcnv101[] = {
   {SDLK_PERIOD,       0x31},  // . >
   {SDLK_SLASH,        0x32},  // / ?
   // _ _
-  {SDLK_RSHIFT,       0x75},  // RShift
+  {SDLK_RSHIFT,       0x7d},  // RShift
   // Kana
   {SDLK_LSUPER,       0x77},  // LSuper (M)
   {SDLK_RCTRL,        0x73},  // GRPH
@@ -498,7 +498,7 @@ static const SDLKCNV sdlcnv101[] = {
   {SDL_SCANCODE_PERIOD,       0x31},  // . >
   {SDL_SCANCODE_SLASH,        0x32},  // / ?
   // _ _
-  {SDL_SCANCODE_RSHIFT,       0x75},  // RShift
+  {SDL_SCANCODE_RSHIFT,       0x7d},  // RShift
   // Kana
   {SDL_SCANCODE_LGUI,         0x77},  // LSuper (M)
   {SDL_SCANCODE_RCTRL,        0x73},  // GRPH
@@ -609,7 +609,7 @@ static const SDLKCNV sdlcnv106[] = {
   {SDLK_PERIOD,       0x31},  // . >
   {SDLK_SLASH,        0x32},  // / ?
   // _ _
-  {SDLK_RSHIFT,       0x75},  // RShift
+  {SDLK_RSHIFT,       0x7d},  // RShift
   // Kana
   {SDLK_LSUPER,       0x77},  // LSuper (M)
   {SDLK_RCTRL,        0x73},  // GRPH
@@ -716,7 +716,7 @@ static const SDLKCNV sdlcnv106[] = {
   {SDL_SCANCODE_PERIOD,         0x31},  // . >
   {SDL_SCANCODE_SLASH,          0x32},  // / ?
   {SDL_SCANCODE_INTERNATIONAL1, 0x33},  // _ _
-  {SDL_SCANCODE_RSHIFT,         0x75},  // RShift
+  {SDL_SCANCODE_RSHIFT,         0x7d},  // RShift
   // Kana
   {SDL_SCANCODE_LGUI,           0x77},  // LSuper (M)
   {SDL_SCANCODE_RCTRL,          0x73},  // GRPH

--- a/windows/winkbd.cpp
+++ b/windows/winkbd.cpp
@@ -52,8 +52,8 @@ static UINT8 key106[256] = {
 //				  NC,0x73,0x4d,  NC,  NC,  NC,  NC,  NC,			// ver0.28
 			//	    ,    ,    ,    ,    ,    ,    ,    		; 0x98
 				  NC,  NC,  NC,  NC,  NC,  NC,  NC,  NC,
-			//	    ,    ,    ,    ,    ,    ,    ,    		; 0xa0
-				  NC,  NC,  NC,  NC,  NC,  NC,  NC,  NC,
+			//	SFTL,SFTR,    ,    ,    ,    ,    ,    		; 0xa0
+				0x70,0x7d,  NC,  NC,  NC,  NC,  NC,  NC,
 			//	    ,    ,    ,    ,    ,    ,    ,    		; 0xa8
 				  NC,  NC,  NC,  NC,  NC,  NC,  NC,  NC,
 			//	    ,    ,    ,    ,    ,    ,    ,    		; 0xb0
@@ -151,6 +151,11 @@ void winkbd_keydown(WPARAM wParam, LPARAM lParam) {
 
 	UINT8	data;
 
+	if (wParam == VK_SHIFT) {
+		UINT scancode = (lParam & 0x00ff0000) >> 16;
+		wParam = MapVirtualKey(scancode, MAPVK_VSC_TO_VK_EX);
+	}
+
 	data = key106[wParam & 0xff];
 	if (data != NC) {
 		if ((data == 0x73) &&
@@ -179,6 +184,10 @@ void winkbd_keyup(WPARAM wParam, LPARAM lParam) {
 
 	UINT8	data;
 
+	if (wParam == VK_SHIFT) {
+		UINT scancode = (lParam & 0x00ff0000) >> 16;
+		wParam = MapVirtualKey(scancode, MAPVK_VSC_TO_VK_EX);
+	}
 	data = key106[wParam & 0xff];
 	if (data != NC) {
 		if ((data == 0x73) &&

--- a/x/gtk2/gtk_keyboard.c
+++ b/x/gtk2/gtk_keyboard.c
@@ -227,7 +227,7 @@ static const UINT8 xkeyconv_misc[256] = {
 	/*	    ,    ,    ,    ,    ,    ,    ,   		; 0xd8 */
 		  NC,  NC,  NC,  NC,  NC,  NC,  NC,  NC,
 	/*	    ,SFTL,SFTR,CTLL,CTLR,CAPS,    ,METL		; 0xe0 */
-		  NC,0x70,0x75,0x74,0x73,0x71,  NC,0x51,
+		  NC,0x70,0x7d,0x74,0x73,0x71,  NC,0x51,
 	/*	METR,ALTL,ALTR,    ,    ,    ,    ,    		; 0xe8 */
 		0x35,0x51,0x35,  NC,  NC,  NC,  NC,  NC,
 	/*	    ,    ,    ,    ,    ,    ,    ,    		; 0xf0 */


### PR DESCRIPTION
SDL2ポート、XポートでMS-DOS、Win98で右シフトが効かなかったので直してみました。

Windows(VS2019 build)やNP21/Wでは右シフトが効いていたのでソースコードを調べたら、キーコードが0x75ではなく0x7dが正しいようなので0x7dにしてみました。MS-DOS、Win98で効くのを確認しました。

なんとなく、更に調べてみるとそもそもWindows(VS2019 build)では右シフトと左シフトキーの区別をしていなかったのでそれも修正しました。💦

---

I fixed it because right shift didn't work on MS-DOS and Win98 with SDL2 port and X port.

Right shift worked on Windows (VS2019 build) and NP21/W, so I checked the source code and the keycode seems to be 0x7d instead of 0x75, so I changed it to 0x7d. I confirmed that it works on MS-DOS and Win98.

Somehow, after further investigation, I found that Windows (VS2019 build) didn't distinguish the right-shift and left-shift keys in the first place, so I fixed that too.
