### PR TITLE
Fixed MSYS2-SDL1 build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,7 +791,12 @@ else()
 	target_sources(NP2kai_SDL_SDL1_base INTERFACE ${NP2kai_SDL_sources} ${NP2kai_Thread_sources} ${NP2kai_TickCount_sources} ${NP2kai_Network_sources})
 	target_compile_definitions(NP2kai_SDL_SDL1_base INTERFACE ${NP2kai_SDL_definitions} ${lib_SDL_mixer_definitions} ${lib_SDL_ttf_definitions} ${NP2kai_extra_definitions} ${NP2kai_LinkBreak_definitions} ${NP2kai_TickCount_definitions} ${NP2kai_Network_definitions} ${SDL_DEFINE} ${SDL_MIXER_DEFINE} ${SDL_TTF_DEFINE} ${lib_usb_definitions})
 	target_include_directories(NP2kai_SDL_SDL1_base INTERFACE ${SDL_INCLUDE_DIR} ${SDL_MIXER_INCLUDE_DIR} ${SDL_TTF_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${lib_usb_include_dirs} ${lib_vst3sdk_include_dirs})
-	target_link_libraries(NP2kai_SDL_SDL1_base INTERFACE ${lib_math_libraries} ${lib_vst3sdk_libraries} ${lib_Threads_libraries} ${SDL_LIBRARY} ${SDL_MIXER_LIBRARY} ${SDL_TTF_LIBRARY} ${lib_SDL_depend_libraries} ${lib_SDL_mixer_depend_libraries} ${lib_SDL_ttf_depend_libraries} ${OPENSSL_LIBRARIES} ${lib_usb_libraries} ${lib_dl_libraries})
+	if(MINGW OR MSYS OR CYGWIN)
+		target_link_libraries(NP2kai_SDL_SDL1_base INTERFACE ${lib_math_libraries} ${lib_vst3sdk_libraries} ${lib_Threads_libraries} ${SDL_LIBRARY} ${SDL_MIXER_LIBRARY} ${SDL_TTF_LIBRARY} ${lib_SDL_depend_libraries} ${lib_SDL_mixer_depend_libraries} ${lib_SDL_ttf_depend_libraries} ${OPENSSL_LIBRARIES} ${lib_usb_libraries} ${lib_dl_libraries} SDL dxguid mad)
+	else()
+		target_link_libraries(NP2kai_SDL_SDL1_base INTERFACE ${lib_math_libraries} ${lib_vst3sdk_libraries} ${lib_Threads_libraries} ${SDL_LIBRARY} ${SDL_MIXER_LIBRARY} ${SDL_TTF_LIBRARY} ${lib_SDL_depend_libraries} ${lib_SDL_mixer_depend_libraries} ${lib_SDL_ttf_depend_libraries} ${OPENSSL_LIBRARIES} ${lib_usb_libraries} ${lib_dl_libraries})
+	endif()
+
 
 	add_library(NP2kai_SDL_SDL2_base INTERFACE)
 	target_sources(NP2kai_SDL_SDL2_base INTERFACE ${NP2kai_SDL_sources} ${NP2kai_Thread_sources} ${NP2kai_TickCount_sources} ${NP2kai_Network_sources})

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ SDL
 2. Run MSYS2 64bit console.
 3. Run follow command.
 ```
-$ pacman -S git cmake make mingw-w64-x86_64-toolchain mingw-w64-x86_64-ntldd mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL mingw-w64-x86_64-SDL_mixer mingw-w64-x86_64-SDL_ttf mingw-w64-x86_64-openssl
+$ pacman -S git cmake make mingw-w64-x86_64-toolchain mingw-w64-x86_64-ntldd mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL mingw-w64-x86_64-SDL_mixer mingw-w64-x86_64-SDL_ttf mingw-w64-x86_64-openssl mingw-w64-x86_64-libusb
 ```
 - Linux
 1. Run follow command.


### PR DESCRIPTION
やらかしてしまったのでプルリクエストし直しました。すいません。

最新のMSYS2でも同じだったので、足りないライブラリをリンクするようにしてみた。

---
I've re-pulled the request because it missed. Sorry.

It was the same with the latest MSYS2, so I tried to link the missing libraries.