### PR TITLE
Fix x/commng.c where crashes can happen due to COMMNG layout change

### DIFF
--- a/x/commng.c
+++ b/x/commng.c
@@ -94,8 +94,7 @@ ncrelease(COMMNG self)
 }
 
 static _COMMNG com_nc = {
-//	COMCONNECT_OFF, ncread, ncwrite, ncwriteretry, ncbeginblocktranster, ncendblocktranster, nclastwritesuccess, ncgetstat, ncmsg, ncrelease
-	COMCONNECT_OFF, ncread, ncwrite, ncwriteretry, nclastwritesuccess, ncgetstat, ncmsg, ncrelease
+	COMCONNECT_OFF, ncread, ncwrite, ncwriteretry, ncbeginblocktranster, ncendblocktranster, nclastwritesuccess, ncgetstat, ncmsg, ncrelease
 };
 
 

--- a/x/gtk2/dialog_sound.c
+++ b/x/gtk2/dialog_sound.c
@@ -1142,8 +1142,8 @@ create_mixer_note(void)
 {
 	GtkWidget *root_widget;
 	GtkWidget *table;
-	GtkWidget *vol_label[NELEMENTS(snd14_adj)];
-	GtkWidget *vol_hscale[NELEMENTS(snd14_adj)];
+	GtkWidget *vol_label[NELEMENTS(mixer_vol_tbl)];
+	GtkWidget *vol_hscale[NELEMENTS(mixer_vol_tbl)];
 	GtkWidget *mixer_default_button;
 	GtkWidget *hbox;
 	int i;


### PR DESCRIPTION
COMMNG 構造体の構造が commit 122c9816 と 33010e61 で変更されて 898b1e58 で戻った時に、 x/commng.c が戻っていなかったので、 X11 ビルドで `com_nc` にアクセスがあった時にクラッシュする問題を修正しました。

しばらくぶりに NP2kai を触ったところ落ちたのを修正したので気づくのが遅くなりましたが、確か Win3.1 を起動する時に気づきました。

---
COMMNG layout was changed in commit 122c9816 and 33010e61, but was reverted in 898b1e58. However x/commng.c was not reverted properly, which caused X11 builds to crash when the dummy `com_nc` was accessed.