### PR TITLE
Fix IDE I/O Read which got deleted at commit c2af9e8

### DIFF
--- a/cbus/ideio.c
+++ b/cbus/ideio.c
@@ -479,6 +479,15 @@ static void readsec(IDEDRV drv) {
 	sec = getcursec(drv);
 	//TRACEOUT(("readsec->drv %d sec %x cnt %d thr %d",
 	//							drv->sxsidrv, sec, drv->mulcnt, drv->multhr));
+	if (sxsi_read(drv->sxsidrv, sec, drv->buf, 512)) {
+		TRACEOUT(("read error!"));
+		goto read_err;
+	}
+	drv->bufdir = IDEDIR_IN;
+	drv->buftc = IDETC_TRANSFEREND;
+	drv->bufpos = 0;
+	drv->bufsize = 512;
+	// READはI/Oポートで読み取るデータが準備できたら割り込み
 	if (1) {
 		drv->status = IDESTAT_DRDY | IDESTAT_DSC | IDESTAT_DRQ;
 		drv->error = 0;


### PR DESCRIPTION
NP21/W r81 マージ時のコミット c2af9e8 で IDE ハードディスクの I/O による読み取りができなくなっていたことにより、 DOS など BIOS を経由するアクセスには影響しなかったものの、 Win9x 32ビットディスクアクセスや WinNT などが動作しなかった問題を修正

![win95disk](https://user-images.githubusercontent.com/94353674/211179190-6dbfe761-fc50-4c03-bd50-70dfede1edb8.png)
![nt351sp5](https://user-images.githubusercontent.com/94353674/211179194-29d3fc7b-7854-4e57-a7ef-16e974f49f10.png)
