### PR TITLE
[Libretro] Fix saving states

### DIFF
--- a/sdl/dosio.c
+++ b/sdl/dosio.c
@@ -295,11 +295,19 @@ short file_getdatetime(FILEH handle, DOSDATE *dosdate, DOSTIME *dostime) {
 
 struct stat sb;
 
+#if defined(__LIBRETRO__)
+	if (fstat(handle, &sb) == 0) {
+		if (cnv_sttime(&sb.st_mtime, dosdate, dostime) == SUCCESS) {
+			return(0);
+		}
+	}
+#else
 	if (fstat(fileno(handle), &sb) == 0) {
 		if (cnv_sttime(&sb.st_mtime, dosdate, dostime) == SUCCESS) {
 			return(0);
 		}
 	}
+#endif
 	return(-1);
 }
 


### PR DESCRIPTION
I was running the core on iOS, and noticed that it would crash on saving the state. I compiled the core with `DEBUG=1`, and ran RetroArch in Xcode with exception breakpoints set so I can see where in the code the crash was happening.

It crashes here:
https://github.com/AZO234/NP2kai/blob/master/sdl/dosio.c#L298

It crashes on executing the `fileno` command:
<img width="1722" alt="Screenshot 2023-01-21 at 10 52 24 PM" src="https://user-images.githubusercontent.com/564774/213907949-bff139ca-8134-4478-bef1-caaaf37a4d11.png">

From the stack trace, it cannot get a mutex lock on the file handle. I don't know why that's happening, but I suspect that this is happening only in libretro builds, and it looks like it's happening for other platforms on libretro as well.

I removed the `fileno` call for libretro, and it results in saving states successfully. I was able to load states successfully as well.
