### PR TITLE
libretro: fix build breakage

### DIFF
--- a/sdl/scrnmng.c
+++ b/sdl/scrnmng.c
@@ -156,6 +156,7 @@ BRESULT scrnmng_create(UINT8 mode) {
 	scrnsurf.extend = 0;																// ?
 
 	scrnmng.enable = TRUE;
+#if !defined(__LIBRETRO__)
 	#if SDL_MAJOR_VERSION != 1
 		if((mode & SCRNMODE_FULLSCREEN) && !scrnmng_isfullscreen()) {
 			scrnmng.flag |= SCRNFLAG_FULLSCREEN;
@@ -166,6 +167,7 @@ BRESULT scrnmng_create(UINT8 mode) {
 			}
 		}
 	#endif
+#endif    /* __LIBRETRO__ */
 	return(SUCCESS);
 }
 


### PR DESCRIPTION
The previous commit on sdl/scrnmgr.c broke the _libretro_ build, add an additional '#ifdef' for a codepath that's not supposed to be used by the libretro core.