### PR TITLE
Fix ATAPI READ CD Mode 1 EDC/ECC over-read

### DIFF
--- a/cbus/atapicmd.c
+++ b/cbus/atapicmd.c
@@ -847,6 +847,18 @@ static void atapi_cmd_read_cd(IDEDRV drv, UINT32 lba, UINT32 nsec) {
 		bufsize = 2352;
 	}else{
 		UINT8 rawdata[2352];
+		/*
+		 * MODE1 raw sector reference layout:
+		 * Sync          12 bytes  [0    .. 11]
+		 * Header         4 bytes  [12   .. 15]
+		 * User Data   2048 bytes  [16   .. 2063]
+		 * EDC            4 bytes  [2064 .. 2067]
+		 * Pad            8 bytes  [2068 .. 2075]
+		 * ECC          276 bytes  [2076 .. 2351]
+		 *
+		 * 参照: MMC-3 Draft Revision 10g, 5.17 READ CD Command
+		 * https://www.13thmonkey.org/documentation/SCSI/mmc3r10g.pdf
+		 */
 		const UINT8 data_selection = drv->buf[9];
 		const UINT8 header_code = (data_selection >> 5) & 0x03;
 		const UINT8 has_header = (header_code == 1) || (header_code == 3);

--- a/cbus/atapicmd.c
+++ b/cbus/atapicmd.c
@@ -810,33 +810,11 @@ static void atapi_cmd_read(IDEDRV drv, UINT32 lba, UINT32 nsec) {
 }
 static void atapi_cmd_read_cd(IDEDRV drv, UINT32 lba, UINT32 nsec) {
 	
-	int i;
-	SXSIDEV	sxsi;
-	CDTRK	trk;
-	UINT	tracks;
-	UINT8 *bufptr;
-	UINT bufsize;
-
-	UINT8 rawdata[2352];
-
-	UINT8 hassync;
-	UINT8 hashead;
-	UINT8 hassubhead;
-	UINT8 hasdata;
-	UINT8 hasedcecc;
-
-	UINT16 isCDDA = 1;
+	UINT bufsize = 0;
 	
 #if defined(NP2_WIN)
 	atapi_thread_drv = drv;
 #endif
-	sxsi = sxsi_getptr(drv->sxsidrv);
-
-	hassync = (drv->buf[9] & 0x80) ? 1 : 0;
-	hassubhead = (drv->buf[9] & 0x40) ? 1 : 0;
-	hashead = (drv->buf[9] & 0x20) ? 1 : 0;
-	hasdata = (drv->buf[9] & 0x10) ? 1 : 0;
-	hasedcecc = (drv->buf[9] & 0x08) ? 1 : 0;
 
 	drv->sector = lba;
 	drv->nsectors = nsec;
@@ -847,16 +825,19 @@ static void atapi_cmd_read_cd(IDEDRV drv, UINT32 lba, UINT32 nsec) {
 		return;
 	}
 
+	SXSIDEV sxsi = sxsi_getptr(drv->sxsidrv);
 	sxsi->cdflag_ecc = (sxsi->cdflag_ecc & ~CD_ECC_BITMASK) | CD_ECC_NOERROR;
-	
-	trk = sxsicd_gettrk(sxsi, &tracks);
-	for (i = 0; i < tracks; i++) {
+
+	UINT tracks = 0;
+	CDTRK trk = sxsicd_gettrk(sxsi, &tracks);
+	UINT16 isCDDA = 1;
+	for (int i = 0; i < tracks; i++) {
 		if (trk[i].str_sec <= (UINT32)drv->sector && (UINT32)drv->sector <= trk[i].end_sec) {
 			isCDDA = (trk[i].adr_ctl == TRACKTYPE_AUDIO);
 			break;
 		}
 	}
-	
+
 	if(isCDDA){
 		// Audio
 		if (sxsicd_readraw(sxsi, drv->sector, drv->buf) != SUCCESS) {
@@ -865,57 +846,50 @@ static void atapi_cmd_read_cd(IDEDRV drv, UINT32 lba, UINT32 nsec) {
 		}
 		bufsize = 2352;
 	}else{
+		UINT8 rawdata[2352];
+		const UINT8 data_selection = drv->buf[9];
+		const UINT8 header_code = (data_selection >> 5) & 0x03;
+		const UINT8 has_header = (header_code == 1) || (header_code == 3);
+		const UINT8 has_subheader = (header_code == 2) || (header_code == 3);
+		const UINT8 has_sync = ((data_selection & 0x80) != 0) && has_header;
+		const UINT8 has_data = (data_selection & 0x10) != 0;
+		const UINT8 has_edcecc = (data_selection & 0x08) != 0;
+
 		// 条件がかなり複雑。
 		// ATAPI CD-ROM Specificationの
 		// Table 99 - Number of Bytes Returned Based on Data Selection Field
 		// を参照
 
-		// MODE1決め打ち
 		if (sxsicd_readraw(sxsi, drv->sector, rawdata) != SUCCESS) {
 			atapi_dataread_errorend(0);
 			return;
 		}
 
 		bufsize = 0;
-		bufptr = drv->buf;
-		if (hassync){
-			if(hashead){
-				// Headerがいるときだけ有効
-				memcpy(bufptr, rawdata, 12);
-				bufptr += 12;
-				bufsize += 12;
-			}
+		UINT8 *bufptr = drv->buf;
+		if (has_sync){
+			memcpy(bufptr, rawdata, 12);
+			bufptr += 12;
+			bufsize += 12;
 		}
-		if (hashead){
+		if (has_header){
 			memcpy(bufptr, rawdata + 12, 4);
 			bufptr += 4;
 			bufsize += 4;
 		}
-		if (hassubhead){
-			// MODE1（本来ないが、User Dataが無いときだけ特例で書く）
-			if(!hasdata){
+		if (has_subheader){
+			if (!has_data) {
 				memset(bufptr, 0, 8);
 				bufptr += 8;
 				bufsize += 8;
-
 			}
-
-			//// XA
-			//memcpy(bufptr, rawdata + 12 + 4, 8);
-
-			//bufptr += 8;
-			//bufsize += 8;
 		}
-		if (hasdata){
+		if (has_data){
 			memcpy(bufptr, rawdata + 12 + 4 + 8, 2048);
 			bufptr += 2048;
 			bufsize += 2048;
 		}
-		if (hasedcecc){
-			// MODE1 raw sector:
-			// Sync [0..11], Header [12..15], User Data [16..2063],
-			// EDC [2064..2067], Pad [2068..2075], ECC [2076..2351].
-			// EDC/ECC field including Pad: [2064..2351] (288 bytes).
+		if (has_edcecc){
 			memcpy(bufptr, rawdata + 12 + 4 + 2048, 288);
 			bufptr += 288;
 			bufsize += 288;

--- a/cbus/atapicmd.c
+++ b/cbus/atapicmd.c
@@ -912,17 +912,11 @@ static void atapi_cmd_read_cd(IDEDRV drv, UINT32 lba, UINT32 nsec) {
 			bufsize += 2048;
 		}
 		if (hasedcecc){
-			//// MODE1
-			//memcpy(bufptr, rawdata + 12 + 4 + 8 + 2048, 4);
-			//memcpy(bufptr + 4, rawdata + 12 + 4 + 8 + 2048 + 12, 276);
-
-			////// XA
-			////memcpy(bufptr, rawdata + 12 + 4 + 8 + 2048, 280);
-			
-			//bufptr += 280;
-			//bufsize += 280;
-
-			memcpy(bufptr, rawdata + 12 + 4 + 8 + 2048, 288);
+			// MODE1 raw sector:
+			// Sync [0..11], Header [12..15], User Data [16..2063],
+			// EDC [2064..2067], Pad [2068..2075], ECC [2076..2351].
+			// EDC/ECC field including Pad: [2064..2351] (288 bytes).
+			memcpy(bufptr, rawdata + 12 + 4 + 2048, 288);
 			bufptr += 288;
 			bufsize += 288;
 		}


### PR DESCRIPTION
ATAPI READ CDのMode 1 EDC/ECCコピー開始位置を2072から2064へ修正し、8 bytesのover-readを解消しました。
メモリ安全の問題を解消するのがこのPRの意図です。
後続のMode 2 Form 1対応を行いやすいよう、Header Code等のデータ選択処理を整理・refactorしました。
refactor のフィーリングが違ったら破棄していただいて構いません。

#220 で警告つぶしていて警告がでて気づきました。#220 とこれは、独立にMergeできます。
警告レベル上げて警告つぶしていくと、バグが見つけやすくなりますね。

---

## 概要

ATAPI READ CDのEDC/ECCコピーで、rawdataの末尾を越えて読み出していた。

## Before

```text
rawdata[2352]

コピー元       [2072 .. 2359]  288 bytes
rawdataの範囲  [0    .. 2351]

範囲内         [2072 .. 2351]  280 bytes
範囲外         [2352 .. 2359]    8 bytes
```

```c
memcpy(bufptr, rawdata + 2072, 288);
```

## After

Mode 1のraw sector layoutに合わせ、EDC/ECC 288 bytesを
`[2064 .. 2351]`からコピーする。

```text
EDC/ECC      288 bytes  [2064 .. 2351]
```

```c
memcpy(bufptr, rawdata + 2064, 288);
```

これにより、`rawdata[2352]`の範囲外読み出しを解消する。

## Refactor

方針：

- 一時変数を使用箇所の近くで宣言（見通しをよくするため、変数のスコープをわかりやすくするため）
- `tracks`と`bufsize`を初期化 （未初期化で不定値とならないようにするため）

## Follow-up

Mode 1とMode 2 Form 1ではUser DataおよびEDC/ECCの配置が異なる。

```text
Mode 1:
User Data   [16   .. 2063] 2048 bytes
EDC/ECC     [2064 .. 2351]  288 bytes

Mode 2 Form 1:
User Data   [24   .. 2071] 2048 bytes
EDC/ECC     [2072 .. 2351]  280 bytes
```

今回のPRでは、セクタ形式を判定してUser DataおよびEDC/ECCの
コピー範囲を切り替える処理は追加しない。

## Reference

- [MMC-3 READ CD specification](https://www.13thmonkey.org/documentation/SCSI/mmc3r10g.pdf)